### PR TITLE
Put style code back

### DIFF
--- a/src-web/components/Topology/viewer/helpers/linkHelper.js
+++ b/src-web/components/Topology/viewer/helpers/linkHelper.js
@@ -179,7 +179,7 @@ export default class LinkHelper {
       }
     })
 
-    links.transition(transition)
+    links.transition(transition).style(('opacity': 1.0))
 
     // move line labels
     if (this.diagramOptions.showLineLabels) {


### PR DESCRIPTION
I think this code was removed by accident when fixing the sonar issue here:
https://github.com/open-cluster-management/application-ui/commit/8319dd23b19742e4ff63149ea2f30113da2ac9ef#diff-e3295856bac0518d0346cbb6de862bb9L174