### PR TITLE
centered topology tooltip

### DIFF
--- a/src-web/components/Topology/viewer/helpers/nodeHelper.js
+++ b/src-web/components/Topology/viewer/helpers/nodeHelper.js
@@ -145,18 +145,13 @@ export default class NodeHelper {
               const { width, height } = ts[j].getBoundingClientRect()
               if (navigator.userAgent.indexOf('Firefox') !== -1) {
                 return {
-                  top: (bb.top - height + window.scrollY - 6).toString() + 'px',
-                  left:
-                    (
-                      bb.left +
-                      bb.width * 0.72 / 2 -
-                      width * 1.02 / 2
-                    ).toString() + 'px'
+                  top: bb.top - height + window.scrollY - 6 + 'px',
+                  left: bb.left + bb.width * 0.72 / 2 - width * 1.02 / 2 + 'px'
                 }
               } else {
                 return {
-                  top: (bb.top - height + window.scrollY - 6).toString() + 'px',
-                  left: (bb.left + bb.width / 2 - width / 2).toString() + 'px'
+                  top: bb.top - height + window.scrollY - 6 + 'px',
+                  left: bb.left + bb.width / 2 - width / 2 + 'px'
                 }
               }
             })


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/1468

<img width="437" alt="Screen Shot 2020-04-07 at 6 29 38 PM" src="https://user-images.githubusercontent.com/39634227/78798600-2f570780-7987-11ea-8586-693bac1a58ae.png">

**Browser**: Firefox
**Comments**: Most tooltips have been fixed/centered (see screenshot above). It seems like the calculation done for tooltip location doesn't work perfectly in any browser so the changes that were made here will only fix the majority of the offset tooltips.