### PR TITLE
Revert clusterSelector back to clusterLabels

### DIFF
--- a/lib/client/queries.js
+++ b/lib/client/queries.js
@@ -278,7 +278,7 @@ export const HCMApplication = gql`
           creationTimestamp
           selfLink
         }
-        clusterSelector
+        clusterLabels
         clusterReplicas
         resourceSelector
         status


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/2059

Previous PR for above issue broke edit application for existing apps that use deprecated clusterLabels property. Reverting it back to clusterLabels in applications query so existing apps can be edited. 