### PR TITLE
Browser warning when leaving unsaved work

### DIFF
--- a/src-web/components/modals/CreateResourceModal.js
+++ b/src-web/components/modals/CreateResourceModal.js
@@ -112,13 +112,20 @@ class CreateResourceModal extends React.PureComponent {
     })
   };
 
-  componentDidUpdate = () => {
+  onUnload = e => {
     if (this.state.dirty) {
-      window.onbeforeunload = () => true
-    } else {
-      window.onbeforeunload = undefined
+      e.preventDefault()
+      e.returnValue = ''
     }
   };
+
+  componentDidMount() {
+    window.addEventListener('beforeunload', this.onUnload)
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('beforeunload', this.onUnload)
+  }
 
   handleEditorChange = yaml => {
     this.setState({ yaml, dirty: true })

--- a/src-web/components/modals/ResourceModal.js
+++ b/src-web/components/modals/ResourceModal.js
@@ -134,17 +134,21 @@ class ResourceModal extends React.PureComponent {
       })
   }
 
+  onUnload = e => {
+    if (this.state.dirty) {
+      e.preventDefault()
+      e.returnValue = ''
+    }
+  };
+
   componentDidMount() {
+    window.addEventListener('beforeunload', this.onUnload)
     this.resourceModal.focus()
   }
 
-  componentDidUpdate = () => {
-    if (this.state.dirty) {
-      window.onbeforeunload = () => true
-    } else {
-      window.onbeforeunload = undefined
-    }
-  };
+  componentWillUnmount() {
+    window.removeEventListener('beforeunload', this.onUnload)
+  }
 
   render() {
     const { open, label, locale, resourceType } = this.props

--- a/src-web/components/modals/ResourceModalRedux.js
+++ b/src-web/components/modals/ResourceModalRedux.js
@@ -116,17 +116,21 @@ class ResourceModal extends React.PureComponent {
     }
   }
 
+  onUnload = e => {
+    if (this.state.dirty) {
+      e.preventDefault()
+      e.returnValue = ''
+    }
+  };
+
   componentDidMount() {
+    window.addEventListener('beforeunload', this.onUnload)
     this.resourceModal.focus()
   }
 
-  componentDidUpdate = () => {
-    if (this.state.dirty) {
-      window.onbeforeunload = () => true
-    } else {
-      window.onbeforeunload = undefined
-    }
-  };
+  componentWillUnmount() {
+    window.removeEventListener('beforeunload', this.onUnload)
+  }
 
   render() {
     const {


### PR DESCRIPTION
Fix for https://github.com/open-cluster-management/backlog/issues/2081

Solution and browser compatibility: https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload

Tested on Chrome Version 81.0.4044.92 and Firefox 68.8.0esr, when create/edit resource dialog is open with unsaved changes, user is warned about leaving the page through browser built-in pop-op on following events:
- Page reload
- URL change
- Browser back button

<img width="620" alt="Screen Shot 2020-05-08 at 10 50 04 AM" src="https://user-images.githubusercontent.com/11761226/81418057-183c3e80-911a-11ea-851b-6920b036fd99.png">
<img width="660" alt="Screen Shot 2020-05-08 at 10 50 16 AM" src="https://user-images.githubusercontent.com/11761226/81418065-196d6b80-911a-11ea-873e-5dc29c9afde4.png">
Tested on Safari Version 13.1, it behaves differently because of a known issue on Safari which is caused by back-forward cache. It is supposed to save complete state of page when user navigates away. Here user is warned about leaving the page through browser built-in pop-op only on:

- Page reload

In case of following events user is not warned but the forward button takes user to the previous state of the page including unsaved changes so user won't lose the unsaved work:
- URL change
- Browser back button

<img width="633" alt="Screen Shot 2020-05-08 at 10 50 40 AM" src="https://user-images.githubusercontent.com/11761226/81418503-c811ac00-911a-11ea-8eaa-22c9afb40d17.png">
 