### PR TITLE
Show multiple success and failure messages for create resource

### DIFF
--- a/nls/platform.properties
+++ b/nls/platform.properties
@@ -345,6 +345,7 @@ error.update.only.placement = Only updating PlacementRule is currently supported
 error.updating.resource = Error:
 success.update.resource = Success:
 success.update.resource.check = Check again later.
+success.create.details = Create {0} {1} was submitted successfully.
 success.default.description = The request completed successfully.
 succes.delete.description = Delete resource {0} was submitted successfully. The result will display in the table when ready.
 success.create.description = Create resource was submitted successfully. The result will display in the table when ready.

--- a/src-web/components/modals/CreateResourceModal.js
+++ b/src-web/components/modals/CreateResourceModal.js
@@ -40,6 +40,7 @@ const initialState = {
   yaml: '',
   yamlParsingError: null,
   createError: null,
+  createSuccess: null,
   dirty: false,
   sample: null
 }
@@ -88,25 +89,29 @@ class CreateResourceModal extends React.PureComponent {
     this.setState({ yamlParsingError: null, processing: true })
 
     this.props.onCreateResource(resources).then(result => {
-      // errors can be in createApplication and createResources depending on type of resource
-      const errors = R.concat(
-        R.pathOr([], ['data', 'createApplication', 'errors'], result),
-        R.pathOr([], ['data', 'createResources', 'errors'], result)
+      const results = R.pathOr(
+        [],
+        ['data', 'createResources', 'result'],
+        result
       )
-
-      if (errors && errors.length > 0) {
-        this.setState({
-          createError: {
-            message: errors[0].message
-          },
-          processing: false
-        })
-      } else {
-        this.setState(initialState)
-        // If there is a on Submit function passed in we want to execute it
-        if (this.props.onSubmitFunction) {
-          waitTime(7000)
-          this.props.onSubmitFunction()
+      if (results && results.length > 0) {
+        const failure = results.filter(
+          r => r.kind === 'Status' && r.status === 'Failure'
+        )
+        const success = results.filter(r => r.kind !== 'Status')
+        if (failure && failure.length > 0) {
+          this.setState({
+            createError: failure,
+            createSuccess: success && success.length > 0 ? success : null,
+            processing: false
+          })
+        } else {
+          this.setState(initialState)
+          // If there is a on Submit function passed in we want to execute it
+          if (this.props.onSubmitFunction) {
+            waitTime(7000)
+            this.props.onSubmitFunction()
+          }
         }
       }
     })
@@ -145,7 +150,6 @@ class CreateResourceModal extends React.PureComponent {
     const tabsHandleEditorChange = this.handleEditorChange
     const tabsHandleParsingError = this.handleParsingError
     const tabsYaml = this.state.yaml
-    const errorMsg = this.state.createError && this.state.createError.message
     return (
       <div>
         <Button
@@ -208,18 +212,54 @@ class CreateResourceModal extends React.PureComponent {
                     onCloseButtonClick={this.handleNotificationClosed}
                   />
               )}
-              {(this.state.createError || errorMsg) && (
-                <InlineNotification
-                  kind="error"
-                  title={msgs.get('error.create', this.context.locale)}
-                  iconDescription=""
-                  // show default msg if errorMsg is not set
-                  subtitle={
-                    errorMsg ||
-                    msgs.get('error.create.reason', this.context.locale)
-                  }
-                  onCloseButtonClick={this.handleNotificationClosed}
-                />
+              {this.state.createError && (
+                <div>
+                  {this.state.createError.map(error => {
+                    return (
+                      <InlineNotification
+                        key={Math.random()}
+                        kind="error"
+                        title={msgs.get('error.create', this.context.locale)}
+                        iconDescription=""
+                        // show default msg if errorMsg is not set
+                        subtitle={
+                          error.message ||
+                          msgs.get('error.create.reason', this.context.locale)
+                        }
+                        onCloseButtonClick={this.handleNotificationClosed}
+                      />
+                    )
+                  })}
+                  {this.state.createSuccess &&
+                    this.state.createSuccess.map(success => {
+                      return (
+                        <InlineNotification
+                          key={Math.random()}
+                          kind="success"
+                          title={msgs.get(
+                            'success.update.resource',
+                            this.context.locale
+                          )}
+                          iconDescription=""
+                          subtitle={
+                            success.kind &&
+                            success.metadata &&
+                            success.metadata.name
+                              ? msgs.get(
+                                'success.create.details',
+                                [success.kind, success.metadata.name],
+                                this.context.locale
+                              )
+                              : msgs.get(
+                                'success.create.description',
+                                this.context.locale
+                              )
+                          }
+                          onCloseButtonClick={this.handleNotificationClosed}
+                        />
+                      )
+                    })}
+                </div>
               )}
               {this.props.sampleTabs ? (
                 <div className="yamlSampleTabsContainer">


### PR DESCRIPTION
Fix for https://github.com/open-cluster-management/backlog/issues/2038

Show multiple error messages instead of the first one only: 

<img width="566" alt="Screen Shot 2020-05-14 at 10 43 17 AM" src="https://user-images.githubusercontent.com/11761226/81948915-40bbb100-95d0-11ea-8c58-a63c1f6e28b4.png">

Show all error and success messages instead of error only: 

<img width="567" alt="Screen Shot 2020-05-14 at 10 43 50 AM" src="https://user-images.githubusercontent.com/11761226/81948922-41ecde00-95d0-11ea-9875-e6c5fe9df04f.png">
