### PR TITLE
fix prop dialog window scroll size

### DIFF
--- a/src-web/components/Topology/viewer/DetailsView.js
+++ b/src-web/components/Topology/viewer/DetailsView.js
@@ -69,7 +69,6 @@ class DetailsView extends React.Component {
       locale,
       onClose,
       getLayoutNodes,
-      getViewContainer,
       staticResourceData,
       selectedNodeId
     } = this.props
@@ -82,8 +81,7 @@ class DetailsView extends React.Component {
       typeToShapeMap[resourceType] || {}
     const details = getNodeDetails(currentNode, locale)
     const name = currentNode.type === 'cluster' ? '' : currentNode.name
-    const height = getViewContainer().getBoundingClientRect().height
-    const scrollHeight = height * 0.86
+
     const searchLink = createResourceSearchLink(currentNode)
     return (
       <section className="topologyDetails">
@@ -107,7 +105,6 @@ class DetailsView extends React.Component {
         </div>
         <hr />
         <Scrollbars
-          style={{ height: scrollHeight }}
           renderView={this.renderView}
           renderThumbVertical={this.renderThumbVertical}
           className="details-view-container"
@@ -323,7 +320,7 @@ class DetailsView extends React.Component {
   }
 
   renderView({ style, ...props }) {
-    style.marginBottom = -17
+    style.height = 'calc(100vh - 340px)'
     return <div {...props} style={{ ...style }} />
   }
 

--- a/tests/jest/components/__snapshots__/DetailsView.test.js.snap
+++ b/tests/jest/components/__snapshots__/DetailsView.test.js.snap
@@ -94,7 +94,7 @@ exports[`DetailsView 1 pod details render as expected 1`] = `
     className="details-view-container"
     style={
       Object {
-        "height": 573.62,
+        "height": "100%",
         "overflow": "hidden",
         "position": "relative",
         "width": "100%",
@@ -106,8 +106,9 @@ exports[`DetailsView 1 pod details render as expected 1`] = `
         Object {
           "WebkitOverflowScrolling": "touch",
           "bottom": 0,
+          "height": "calc(100vh - 340px)",
           "left": 0,
-          "marginBottom": -17,
+          "marginBottom": 0,
           "marginRight": 0,
           "overflow": "scroll",
           "position": "absolute",
@@ -447,7 +448,7 @@ exports[`DetailsView no components renders as expected 1`] = `
     className="details-view-container"
     style={
       Object {
-        "height": NaN,
+        "height": "100%",
         "overflow": "hidden",
         "position": "relative",
         "width": "100%",
@@ -459,8 +460,9 @@ exports[`DetailsView no components renders as expected 1`] = `
         Object {
           "WebkitOverflowScrolling": "touch",
           "bottom": 0,
+          "height": "calc(100vh - 340px)",
           "left": 0,
-          "marginBottom": -17,
+          "marginBottom": 0,
           "marginRight": 0,
           "overflow": "scroll",
           "position": "absolute",


### PR DESCRIPTION
before
<img width="1088" alt="Screen Shot 2020-06-22 at 11 53 14 AM" src="https://user-images.githubusercontent.com/43010150/85308314-138bd980-b47f-11ea-89ca-13d6f205b10b.png">
<img width="960" alt="Screen Shot 2020-06-22 at 11 52 56 AM" src="https://user-images.githubusercontent.com/43010150/85308321-1686ca00-b47f-11ea-9884-e776c8986a61.png">

with the fix

<img width="1389" alt="Screen Shot 2020-06-22 at 11 53 42 AM" src="https://user-images.githubusercontent.com/43010150/85308342-1c7cab00-b47f-11ea-9cd0-b358da39e247.png">
<img width="654" alt="Screen Shot 2020-06-22 at 11 48 19 AM" src="https://user-images.githubusercontent.com/43010150/85308363-21415f00-b47f-11ea-9a54-1cc6b287e366.png">
