### PR TITLE
App topology doesn't show resources with a release label

### DIFF
--- a/src-web/components/Topology/utils/diagram-helpers.js
+++ b/src-web/components/Topology/utils/diagram-helpers.js
@@ -691,8 +691,11 @@ export const createResourceSearchLink = node => {
 export const getNameWithoutChartRelease = (relatedKind, name) => {
   const kind = _.get(relatedKind, 'kind', '')
 
-  if (kind === 'subscription') {
-    return name //ignore subscription objects
+  if (
+    kind === 'subscription' ||
+    name !== _.get(relatedKind, '_hostingDeployable', '')
+  ) {
+    return name //ignore subscription objects or objects where the name is not created from the _hostingDeployable
   }
 
   //for resources deployed from charts, remove release name
@@ -707,7 +710,7 @@ export const getNameWithoutChartRelease = (relatedKind, name) => {
       splitLabelContent.length === 2 &&
       _.trim(splitLabelContent[0]) === 'release'
     ) {
-      //get for release name
+      //get label for release name
       foundReleaseLabel = true
       const releaseName = _.trim(splitLabelContent[1])
       name = _.replace(name, `${releaseName}-`, '')

--- a/tests/jest/components/Topology/viewer/utils/diagram-helpers.test.js
+++ b/tests/jest/components/Topology/viewer/utils/diagram-helpers.test.js
@@ -603,7 +603,7 @@ describe("getNameWithoutChartRelease node with pods no _hostingDeployable", () =
   it("getNameWithoutChartRelease for pod with no deployable", () => {
     expect(
       getNameWithoutChartRelease(node, "nginx-ingress-edafb-default-backend")
-    ).toEqual("default-backend");
+    ).toEqual("nginx-ingress-edafb-default-backend");
   });
 });
 


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/3412

<img width="1371" alt="Screen Shot 2020-07-09 at 4 31 44 AM" src="https://user-images.githubusercontent.com/43010150/87018596-7976a180-c19f-11ea-9240-f6863f4ad197.png">

with the fix

<img width="1370" alt="Screen Shot 2020-07-09 at 4 49 33 AM" src="https://user-images.githubusercontent.com/43010150/87018716-a1660500-c19f-11ea-9946-9da34eea19cf.png">
