### PR TITLE
Fix node link direction

### DIFF
--- a/src-web/components/Topology/viewer/helpers/linkHelper.js
+++ b/src-web/components/Topology/viewer/helpers/linkHelper.js
@@ -377,6 +377,12 @@ const routeEdge = (
   return preparedColaRouting
 }
 
+export const processColaEdge = colaEdge => {
+  if (colaEdge) {
+    [colaEdge.target, colaEdge.source] = [colaEdge.source, colaEdge.target]
+  }
+}
+
 // do parallel, avoidance, self link layouts
 export const layoutEdges = (
   newLayout,
@@ -410,12 +416,7 @@ export const layoutEdges = (
           layout.isSwapped = nodeMap[sid].position.x > nodeMap[tid].position.x
           if (layout.isSwapped) {
             [tid, sid] = [sid, tid]
-            if (colaEdge) {
-              [colaEdge.target, colaEdge.source] = [
-                colaEdge.source,
-                colaEdge.target
-              ]
-            }
+            processColaEdge(colaEdge)
           }
         }
 


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/3398

<img width="1525" alt="image" src="https://user-images.githubusercontent.com/38960034/87095122-2c7de400-c20e-11ea-8737-498c671076c7.png">

Not sure why it makes a difference but I had to revert this change:
https://github.com/open-cluster-management/application-ui/commit/9faabd41693f8faf21d9485f2509455bd278ea58#diff-e3295856bac0518d0346cbb6de862bb9