### PR TITLE
Add step to publish app-ui test image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,4 +99,5 @@ jobs:
         - |
           make 
           make pipeline-manifest/update PIPELINE_MANIFEST_COMPONENT_SHA256=${TRAVIS_COMMIT} PIPELINE_MANIFEST_COMPONENT_REPO=${TRAVIS_REPO_SLUG} PIPELINE_MANIFEST_BRANCH=${TRAVIS_BRANCH}
-  
+        - echo "Waiting 60s before publishing test image..." && sleep 60
+        - make publish-test-image


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/2437

adding the publish step for the test image, same as what console-ui uses:
https://github.com/open-cluster-management/console-ui/blob/master/.travis.yml