### PR TITLE
filter the application table by app name to avoid pagination issues

### DIFF
--- a/tests/cypress/tests/application.spec.js
+++ b/tests/cypress/tests/application.spec.js
@@ -141,7 +141,7 @@ describe("Application Resources", () => {
             appCount_b4 = rowCount;
           });
         }
-        cy.createAppResource("application", "github");
+        cy.createAppResource("application", "namespace");
         pageLoader.shouldNotExist();
         modal.shouldNotBeVisible();
         cy
@@ -210,7 +210,7 @@ describe("Application Resources", () => {
             appCount_b4 = rowCount;
           });
         }
-        cy.createAppResource("application", "github");
+        cy.createAppResource("application", "helmrepo");
         pageLoader.shouldNotExist();
         modal.shouldNotBeVisible();
         cy
@@ -279,7 +279,7 @@ describe("Application Resources", () => {
             appCount_b4 = rowCount;
           });
         }
-        cy.createAppResource("application", "github");
+        cy.createAppResource("application", "objectbucket");
         pageLoader.shouldNotExist();
         modal.shouldNotBeVisible();
         cy


### PR DESCRIPTION
Improvements to work in https://github.com/open-cluster-management/backlog/issues/3632

Because we are having so many PR runs, we have to deal with pagination, but this can be resolved by simply filtering by the app name that we create.