### PR TITLE
always enable Save

### DIFF
--- a/src-web/components/TemplateEditor/TemplateEditor.js
+++ b/src-web/components/TemplateEditor/TemplateEditor.js
@@ -1035,7 +1035,6 @@ export default class TemplateEditor extends React.Component {
             id={createBtn}
             onClick={this.handleCreateResource.bind(this)}
             kind={'primary'}
-            disabled={!this.state.hasUndo}
           >
             {msgs.get('button.create', locale)}
           </Button>,


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/4533

I was trying to disable the Save button if there was no change in the editor
It seems that the change I put in only works if the YAML editor is visible

I am removing the change completely since I know John is planning to make some change to the editor; we'll review this disable action support later