### PR TITLE
Canary fix

### DIFF
--- a/tests/cypress/views/common.js
+++ b/tests/cypress/views/common.js
@@ -105,7 +105,7 @@ export const modal = {
 export const notification = {
   shouldExist: type =>
     cy
-      .get(`.bx--inline-notification[kind="${type}"]`, { timeout: 10000 })
+      .get(`.bx--inline-notification[kind="${type}"]`, { timeout: 50 * 1000 })
       .should("exist")
 };
 


### PR DESCRIPTION
Add longer timeout for validating the notification message
https://github.com/open-cluster-management/backlog/issues/4658#issuecomment-677895402