### PR TITLE
Increase tooltip width for save button

### DIFF
--- a/scss/common.scss
+++ b/scss/common.scss
@@ -301,3 +301,7 @@ body {
 .bx--tooltip--definition .bx--tooltip__trigger:hover {
   border-bottom: none;
 }
+
+.bx--tooltip--definition .bx--tooltip__trigger:hover + .bx--tooltip--definition__bottom {
+  min-width: 150px;
+}


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/4536

<img width="372" alt="image" src="https://user-images.githubusercontent.com/38960034/92939309-9dfb2e00-f41b-11ea-801e-19f8e767127a.png">
