### PR TITLE
Add a delay to popover close after hover

### DIFF
--- a/src-web/components/common/LabelWithPopover.js
+++ b/src-web/components/common/LabelWithPopover.js
@@ -11,25 +11,41 @@ resources(() => {
 })
 
 const LabelWithPopover = ({ children, labelContent, labelIcon }) => {
+  const hoverDelay = 1500
   const [
-    { popoverOpen, popoverPinnedOpen, justClosed },
+    { popoverOpen, popoverPinnedOpen, justClosed, timeout },
     setPopoverState
   ] = useState({
     popoverOpen: false,
     popoverPinnedOpen: false,
-    justClosed: false
+    justClosed: false,
+    timeout: null
   })
 
   const closePopover = () => {
-    setPopoverState(prevState => ({ ...prevState, popoverOpen: false }))
+    const newTimeout = setTimeout(
+      () =>
+        setPopoverState(prevState => ({
+          ...prevState,
+          popoverOpen: false,
+          timeout: null
+        })),
+      hoverDelay
+    )
+    setPopoverState(prevState => ({ ...prevState, timeout: newTimeout }))
   }
 
   const openPopover = () => {
-    setPopoverState(prevState => ({ ...prevState, popoverOpen: true }))
+    setPopoverState(prevState => {
+      if (timeout) {
+        clearTimeout(timeout)
+      }
+      return { ...prevState, popoverOpen: true, timeout: null }
+    })
   }
 
   const shouldClose = () => {
-    const pinned = popoverOpen && !popoverPinnedOpen
+    const pinned = popoverOpen && !popoverPinnedOpen && !timeout
     setPopoverState({
       popoverOpen: pinned,
       popoverPinnedOpen: pinned,
@@ -56,6 +72,8 @@ const LabelWithPopover = ({ children, labelContent, labelIcon }) => {
         isVisible={popoverOpen || popoverPinnedOpen}
         shouldClose={shouldClose}
         shouldOpen={pinPopover}
+        onPointerEnter={openPopover}
+        onPointerLeave={closePopover}
         className="label-with-popover"
         enableFlip
         position="bottom"

--- a/tests/jest/config/platform-properties.json
+++ b/tests/jest/config/platform-properties.json
@@ -101,6 +101,7 @@
   "creation.app.loading.secrets.ns.err": "To select existing secrets, application Namespace must be set first",
   "specs.k8sJob.templateName": "Ansible Tower Job template name",
   "specs.k8sJob.secretName": "Ansible Tower secret",
+  "creation.app.loading.branch.error": "The connection to the Git repository had failed, cannot get branches.",
   "description.ansible.task.status": "Ansible Task status",
   "description.noSubs.title": "No subscriptions found",
   "description.noChannels.title": "No channels found",


### PR DESCRIPTION
open-cluster-management/backlog#5318

Popovers now remain open for 1.5 seconds after hovering on the label, and will also remain open if you hover over the popover itself. It will close immediately upon click elsewhere on the page.

You can still pin a popover by clicking the label, which also causes other popovers to close immediately.