### PR TITLE
Use separate class for height/scroll behaviour

### DIFF
--- a/scss/channel-labels.scss
+++ b/scss/channel-labels.scss
@@ -2,9 +2,6 @@
 @import 'scss/variables';
 
 .channel-labels {
-  max-height: 360px;
-  overflow: scroll;
-
   .channel-type-label {
     font-size: 12px;
     --pf-l-split--m-gutter--MarginRight: 8px;
@@ -36,4 +33,9 @@
     font-weight: 600;
     padding-right: 6px;
   }
+}
+
+.channel-labels-popover-content {
+  max-height: 360px;
+  overflow-y: auto;
 }

--- a/src-web/components/common/ChannelLabels.js
+++ b/src-web/components/common/ChannelLabels.js
@@ -46,7 +46,7 @@ const ChannelLabels = ({ channels, locale }) => {
                 </Split>
               }
             >
-              <Stack className="channel-labels">
+              <Stack className="channel-labels channel-labels-popover-content">
                 {channelMap[chType].map((channel, index) => {
                   const pathname = channel.pathname
                   const link =


### PR DESCRIPTION
open-cluster-management/backlog#5375

Thanks @richiepiya for finding the `overflow-y: auto;` style that should address the issue of scrollbars always being present in Firefox on Windows.