### PR TITLE
Prevent read-only user from clicking create app button

### DIFF
--- a/src-web/components/common/CreateApplicationButton.js
+++ b/src-web/components/common/CreateApplicationButton.js
@@ -49,14 +49,12 @@ class CreateApplicationButton extends Component {
       : undefined
     return (
       <TooltipContainer tooltip={titleText} isDisabled={canDisable}>
-        {/* Disable click for the link */}
         <Link
           to={{
             pathname: path,
             state: { cancelBack: true }
           }}
           key="create-application"
-          onClick={canDisable ? this.disableClick : undefined}
         >
           <Button variant="primary" isSmall isDisabled={canDisable}>
             {msgs.get('actions.create.application', locale)}


### PR DESCRIPTION
open-cluster-management/backlog#5911

Looks like disabling the button is not enough, needed to also disable the link that was put around the button.