### PR TITLE
trim white spaces for combo boxes

### DIFF
--- a/src-web/components/TemplateEditor/components/ControlPanelComboBox.js
+++ b/src-web/components/TemplateEditor/components/ControlPanelComboBox.js
@@ -210,9 +210,9 @@ class ControlPanelComboBox extends React.Component {
           item.style.display = ''
         }
       })
-      control.typing = evt
+      control.typing = evt.trim()
     } else {
-      control.active = evt
+      control.active = evt.trim()
       this.handleComboboxChange(control, userData, controlData)
     }
   }


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/5805

This trims the spaces from only the beginning and end of combo box inputs (ex: repo type url, git branch, git path boxes) so spaces inside the input string won't be removed.