### PR TITLE
fix ansible and pr selection

### DIFF
--- a/lib/client/queries.js
+++ b/lib/client/queries.js
@@ -205,9 +205,10 @@ export const HCMSubscriptionList = gql`
     }
   }
 `
+
 export const HCMPlacementRuleList = gql`
-  query searchSchema {
-    placementrules {
+  query getPlacementRules($namespace: String) {
+    placementrules(namespace: $namespace) {
       metadata {
         name
         namespace

--- a/src-web/components/ApplicationCreationPage/components/ClusterSelector.js
+++ b/src-web/components/ApplicationCreationPage/components/ClusterSelector.js
@@ -258,7 +258,7 @@ export class ClusterSelector extends React.Component {
     if (targetName) {
       const { active } = control
       if (targetName === 'clusterSelector-checkbox') {
-        active.mode = event.target.checked
+        active.mode = event.target.checked ? true : false
       } else {
         const { clusterLabelsList } = active
         const labelID = parseInt(event.target.id.split('-')[1], 0)

--- a/src-web/components/ApplicationCreationPage/controlData/ControlDataPlacement.js
+++ b/src-web/components/ApplicationCreationPage/controlData/ControlDataPlacement.js
@@ -35,8 +35,20 @@ const existingRuleCheckbox = 'existingrule-checkbox'
 const localClusterCheckbox = 'local-cluster-checkbox'
 
 export const loadExistingPlacementRules = () => {
+  const getQueryVariables = (control, globalControl) => {
+    const nsControl = globalControl.find(
+      ({ id: idCtrl }) => idCtrl === 'namespace'
+    )
+    if (nsControl.active) {
+      delete control.exception
+      return { namespace: nsControl.active }
+    } else {
+      return { namespace: '_undefined_' }
+    }
+  }
   return {
     query: HCMPlacementRuleList,
+    variables: getQueryVariables,
     loadingDesc: 'creation.app.loading.rules',
     setAvailable: setAvailableRules.bind(null)
   }
@@ -206,7 +218,7 @@ const placementData = [
   },
   {
     id: existingRuleCheckbox,
-    type: 'hidden',
+    type: 'checkbox',
     name: 'creation.app.settings.existingRule',
     tooltip: 'tooltip.creation.app.settings.existingRule',
     onSelect: updateDisplayForPlacementControls,

--- a/src-web/components/ApplicationCreationPage/controlData/utils.js
+++ b/src-web/components/ApplicationCreationPage/controlData/utils.js
@@ -135,8 +135,6 @@ export const updateChannelControls = (
   const nsControl = globalControl.find(
     ({ id: idCtrl }) => idCtrl === 'namespace'
   )
-  updateControlsForNS(urlControl, nsControl, globalControl)
-
   const { active, availableData, groupControlData } = urlControl
   const pathData = availableData[active]
 
@@ -417,30 +415,16 @@ export const setAvailableRules = (control, result) => {
   control.isLoading = false
   control.active = ''
 
-  const selectedNS = control.ns
   const error = placementrules ? null : result.error
 
   if (error) {
     control.isFailed = true
   } else if (placementrules) {
-    if (_.get(control, 'ns', '') === '') {
-      control.available = [] // no app namespace selected so no rule to show
-    } else {
-      control.availableData = _.keyBy(
-        placementrules.filter(
-          rule => _.get(rule, 'metadata.namespace', '') === selectedNS
-        ),
-        'metadata.name'
-      )
+    if (placementrules.length > 0) {
+      control.availableData = _.keyBy(placementrules, 'metadata.name')
       control.available = Object.keys(control.availableData).sort()
-      if (Object.keys(control.availableData).length === 0) {
-        _.set(control, 'type', 'hidden')
-        const groupControlData = _.get(control, 'groupControlData')
-        const existingRule = groupControlData.find(
-          ({ id }) => id === existingRuleCheckbox
-        )
-        existingRule && _.set(existingRule, 'type', 'hidden')
-      }
+    } else {
+      control.availableData = []
     }
   } else {
     control.isLoading = loading


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/5915

With this change, the secret and PR selection is not affected by the channel selection change

With this change, 
- if no ns is selected you should see the select existing PR checkbox, but the combo is empty ( No resources found message )
- The same happens if the ns has no PR ( No resources found message )
- if the selected ns has PR's they are going to show up in the combo
<img width="729" alt="Screen Shot 2020-10-06 at 9 13 52 PM" src="https://user-images.githubusercontent.com/43010150/95276472-492fb500-0819-11eb-9b7b-52ba4e725567.png">
<img width="678" alt="Screen Shot 2020-10-06 at 9 14 19 PM" src="https://user-images.githubusercontent.com/43010150/95276479-4af97880-0819-11eb-81ba-edf3e9cbcf19.png">
<img width="748" alt="Screen Shot 2020-10-06 at 9 14 35 PM" src="https://user-images.githubusercontent.com/43010150/95276482-4b920f00-0819-11eb-802d-0d0187ab6e37.png">


