### PR TITLE
remove check on app.kubernetes.io/name

### DIFF
--- a/src-web/components/Topology/utils/diagram-helpers.js
+++ b/src-web/components/Topology/utils/diagram-helpers.js
@@ -783,12 +783,6 @@ export const getNameWithoutChartRelease = (
     const splitLabelContent = _.split(label, '=')
     if (
       splitLabelContent.length === 2 &&
-      _.trim(splitLabelContent[0]) === 'app.kubernetes.io/name'
-    ) {
-      name = splitLabelContent[1] //use app.kubernetes.io/name as name if set
-    }
-    if (
-      splitLabelContent.length === 2 &&
       _.trim(splitLabelContent[0]) === 'release'
     ) {
       //get label for release name

--- a/tests/jest/components/Topology/viewer/utils/diagram-helpers.test.js
+++ b/tests/jest/components/Topology/viewer/utils/diagram-helpers.test.js
@@ -723,33 +723,6 @@ describe("getNameWithoutChartRelease node with the pod name same as the release 
   });
 });
 
-describe("getNameWithoutChartRelease node with app.kubernetes.io/name label", () => {
-  const node = {
-    apiversion: "v1",
-    cluster: "sharingpenguin",
-    container: "slave",
-    created: "2020-05-26T19:18:21Z",
-    kind: "pod",
-    label:
-      "app.kubernetes.io/name=controller; app=nginx-ingress; chart=nginx-ingress-1.36.3; component=default-backend; heritage=Helm; release=nginx-ingress-edafb",
-    name: "nginx-ingress-edafb",
-    namespace: "app-guestbook-git-ns",
-    restarts: 0,
-    selfLink:
-      "/api/v1/namespaces/app-guestbook-git-ns/pods/redis-slave-5bdcfd74c7-22ljj",
-    startedAt: "2020-05-26T19:18:21Z",
-    status: "Running"
-  };
-
-  it("getNameWithoutChartRelease for pod with app.kubernetes.io/name label", () => {
-    expect(
-      getNameWithoutChartRelease(node, "nginx-ingress-edafb-aaa-controller", {
-        value: true
-      })
-    ).toEqual("controller");
-  });
-});
-
 describe("getNameWithoutChartRelease node with release name plus pod name", () => {
   const node = {
     apiversion: "v1",


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/5969

summary
Discussed this with @mikeshng and the conclusion is that here is no workaround now we can add in the UI to safely cover all scenarios
There is simply not enough information to be able to match the deployable with the deployed resources unless we set an alias on the chart. So no matter what assumption we make, without the alias we are breaking some cases
The plan

I am going to remove the fix I put in
the right fix is for the backend to add extra information when the alias is missing; this is too complex and cannot be done in 2.1, so we request this to be moved to 2.2
For 2.1, we recommend that the user sets an alias when deploying a chart; we will open a known issue for this
Mike is testing the alias workaround