### PR TITLE
fix channel name size

### DIFF
--- a/src-web/components/ApplicationCreationPage/controlData/utils.js
+++ b/src-web/components/ApplicationCreationPage/controlData/utils.js
@@ -95,6 +95,9 @@ export const getUniqueChannelName = (channelPath, groupControlData) => {
   channelName = _.replace(channelName, /:/g, '')
   channelName = _.replace(channelName, /\//g, '-')
 
+  //max name for ns or resources is 63 chars
+  // trim channel name to max 58 char to allow a max of 63 char length
+  //for the channel authentication (which is channelName-auth) object and channel ns (channelName-ns)
   if (channelName.length > 58) {
     channelName = channelName.substring(channelName.length - 56)
   }

--- a/tests/jest/components/CreateApplicationPage/controlData/ControlData.test.js
+++ b/tests/jest/components/CreateApplicationPage/controlData/ControlData.test.js
@@ -107,7 +107,7 @@ describe("getUniqueChannelName", () => {
   ];
 
   const result = "gle-samples-with-path-longer-than-60-characters-test-long";
-  it("getUniqueChannelName too long", () => {
+  it("getUniqueChannelName shortens long URLs", () => {
     expect(getUniqueChannelName(channelUrl, groupControlData)).toEqual(result);
   });
 });


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/6033

The fix is to trim the beginning of the channel name if the computed name is longer then 63 char