### PR TITLE
Remove useless channel namespace cleanup code

### DIFF
--- a/tests/cypress/tests/04-delete/02-delete-resources.spec.js
+++ b/tests/cypress/tests/04-delete/02-delete-resources.spec.js
@@ -10,10 +10,6 @@ import {
 } from "../../views/resources";
 
 describe("Cleanup resouces", () => {
-  it("delete unused channel namespaces on hub cluster", () => {
-    deleteUnusedChannelNamespaces();
-  });
-
   const kubeconfigs = Cypress.env("KUBE_CONFIG");
   for (const type in config) {
     const data = config[type].data;


### PR DESCRIPTION
Channel cleanup is no longer needed. @sahare's cascading delete of applications will automatically delete the channel when the last application using it is deleted by the tests.

As for the namespace, it is no longer named according to the application, so if we want to clean those up, we would need to calculate the names of the namespaces from our channel pathnames in the sample data in the same way @birsanv's code does. Previously we could match the namespace names based on a pattern.

We only use about 3 different paths in our channels for testing, so the number of namespaces left behind by testing will not grow any larger than this, except when the naming scheme is adjusted.