### PR TITLE
Fix UI crash when switching between subscriptions

### DIFF
--- a/src-web/components/Topology/viewer/DetailsView.js
+++ b/src-web/components/Topology/viewer/DetailsView.js
@@ -81,7 +81,8 @@ class DetailsView extends React.Component {
     const currentNode =
       getLayoutNodes().find(n => n.uid === selectedNodeId) || {}
     const { layout = {} } = currentNode
-    const resourceType = layout.type || currentNode.type
+    const resourceType =
+      layout.type || currentNode.type || currentUpdatedNode.type
     const { shape = 'other', className = 'default' } =
       typeToShapeMap[resourceType] || {}
     const details = getNodeDetails(currentNode, currentUpdatedNode, locale)

--- a/src-web/components/Topology/viewer/defaults/titles.js
+++ b/src-web/components/Topology/viewer/defaults/titles.js
@@ -68,6 +68,9 @@ export const getSectionTitles = (clusters, types, environs, locale) => {
 }
 
 export const getLegendTitle = (type, locale) => {
+  if (type === undefined) {
+    return ''
+  }
   switch (type) {
   case 'deploymentconfig':
   case 'replicationcontroller':

--- a/tests/jest/components/Topology/viewer/defaults/titles.test.js
+++ b/tests/jest/components/Topology/viewer/defaults/titles.test.js
@@ -25,7 +25,8 @@ describe("getLegendTitle", () => {
     ["application", "Application"],
     ["placements", "Placements"],
     ["unknown", "Unknown"],
-    ["", ""]
+    ["", ""],
+    [undefined, ""]
   ]);
 
   it("should get the correct title", () => {


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/6098

Changed the code to use the currentUpdateNode as a backup when looking for the node type, also added an undefined check for the node type when returning the legend.