### PR TITLE
fix for editing multiple time intervals

### DIFF
--- a/src-web/components/ApplicationCreationPage/components/TimeWindow.js
+++ b/src-web/components/ApplicationCreationPage/components/TimeWindow.js
@@ -571,7 +571,7 @@ export const reverse = (control, templateObject) => {
       timezone: timezone && timezone.$v,
       showTimeSection,
       timeList,
-      timeListID: 1
+      timeListID: timeList.length
     }
   }
 }


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/6219

On edit mode only, if you create a subscription with a time window containing more then one time interval, the time interval is not saved properly

<img width="742" alt="Screen Shot 2020-10-15 at 9 41 21 AM" src="https://user-images.githubusercontent.com/43010150/96138769-1bf39e80-0ecc-11eb-8142-d317a667066a.png">
