### PR TITLE
fix res mapping for multi subs

### DIFF
--- a/src-web/components/ApplicationTopologyModule/definitions/hcm-application-diagram.js
+++ b/src-web/components/ApplicationTopologyModule/definitions/hcm-application-diagram.js
@@ -94,18 +94,18 @@ export const processNodeData = (
         : undefined
     isHelmRelease.value =
       topoAnnotation !== undefined && topoAnnotation.indexOf('helmchart/') > -1
-  } else if (clusterName.indexOf(', ') > -1) {
-    topoResourceMap[`${type}-${keyName}`] = node
-    podsKeyForThisNode = `pod-${keyName}`
-    isClusterGrouped.value = true
   } else {
     topoResourceMap[`${type}-${keyName}-${clusterName}`] = node
     podsKeyForThisNode = `pod-${keyName}-${clusterName}`
+
+    if (clusterName.indexOf(', ') > -1) {
+      isClusterGrouped.value = true
+    }
   }
-  if (type === 'route') {
-    //keep clusters info to create route host
-    node['clusters'] = R.find(R.propEq('type', 'cluster'))(topology.nodes)
-  }
+  //keep clusters info to create route host and to match nodes to grouped clusters
+  node['clusters'] = R.find(R.propEq('id', `member--clusters--${clusterName}`))(
+    topology.nodes
+  )
 
   if (nodeMustHavePods(node)) {
     //keep a map with the nodes names that could have pods


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/6256

The issue happens when the app has more then one subscription deploying the same (Kind, name) object and when at least one subscription deploys to more than one cluster 
The deployed object fails to find the right group of cluster to insert itself, when the cluster nodes are grouped 

The fix makes all deployed objects to look for matching deployables not only by kind and name, but also by cluster

Without the fix

<img width="1411" alt="Screen Shot 2020-10-19 at 9 26 58 AM" src="https://user-images.githubusercontent.com/43010150/96473888-2b425700-1200-11eb-8c12-fa6960dc3d64.png">


With the fix 

<img width="716" alt="Screen Shot 2020-10-19 at 11 28 20 AM" src="https://user-images.githubusercontent.com/43010150/96473783-0d74f200-1200-11eb-9a76-2fa682d55c4a.png">

<img width="1347" alt="Screen Shot 2020-10-19 at 11 51 32 AM" src="https://user-images.githubusercontent.com/43010150/96475041-8d4f8c00-1201-11eb-962f-64060fefb527.png">
<img width="1267" alt="Screen Shot 2020-10-19 at 11 51 59 AM" src="https://user-images.githubusercontent.com/43010150/96475043-8e80b900-1201-11eb-910c-af0a72f782ce.png">
