### PR TITLE
cover local deployment scenario

### DIFF
--- a/src-web/components/Topology/utils/diagram-helpers.js
+++ b/src-web/components/Topology/utils/diagram-helpers.js
@@ -975,7 +975,7 @@ export const setupResourceModel = (
                 _.get(
                   resourceMapForObject,
                   'clusters.specs.sortedClusterNames',
-                  []
+                  [LOCAL_HUB_NAME] // if no cluster found for this resource, this could be a local deployment
                 ),
                 _.get(relatedKind, 'cluster')
               )


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/6256

<img width="1115" alt="Screen Shot 2020-10-19 at 3 12 15 PM" src="https://user-images.githubusercontent.com/43010150/96501059-ce559980-121d-11eb-8ca7-41da071d7b82.png">


I also tested with 3 subscriptions, 2 local, 1 local + 2 remote

The subscription with 1 local + 2 remote intersects with one of the local subscriptions ( deploys the same resource )
The topology shows what I expect it should : both subscriptions show the deployable and the deployed object is linked to both
fyi @fxiang1 

<img width="1407" alt="Screen Shot 2020-10-19 at 3 42 14 PM" src="https://user-images.githubusercontent.com/43010150/96503920-f941ec80-1221-11eb-8fdf-b7bd8238caf5.png">


<img width="1350" alt="Screen Shot 2020-10-19 at 3 41 46 PM" src="https://user-images.githubusercontent.com/43010150/96503912-f6df9280-1221-11eb-902f-8b7c081f4c0a.png">

without the fix

<img width="1368" alt="Screen Shot 2020-10-19 at 3 48 39 PM" src="https://user-images.githubusercontent.com/43010150/96504396-9ef55b80-1222-11eb-92ce-3728178d508a.png">
