### PR TITLE
Ignore TemplateEditor in test coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,7 +17,11 @@ const tapReporter = [
 
 const jestConfig = {
   collectCoverage: true,
-  collectCoverageFrom: ['src-web/**/*.{js,jsx}', '!**/src-web/index.js'],
+  collectCoverageFrom: [
+    'src-web/**/*.{js,jsx}',
+    '!**/src-web/index.js',
+    '!**/src-web/components/TemplateEditor/**'
+  ],
   coverageDirectory: './test-output/coverage',
   coverageReporters: [
     'json-summary',


### PR DESCRIPTION
Exclude the whole TemplateEditor folder from collectCoverageFrom in jest configuration

Coverage report before excluding TemplateEditor:

<img width="747" alt="Screen Shot 2020-10-27 at 2 54 32 PM" src="https://user-images.githubusercontent.com/11761226/97350073-ab069c00-1866-11eb-9064-37e4778b6430.png">


Coverage report after excluding TemplateEditor:

<img width="734" alt="Screen Shot 2020-10-27 at 3 07 27 PM" src="https://user-images.githubusercontent.com/11761226/97350133-bfe32f80-1866-11eb-82e5-3cef1f16a849.png">
