### PR TITLE
use deploy to all online option

### DIFF
--- a/tests/cypress/config/config.func.yaml
+++ b/tests/cypress/config/config.func.yaml
@@ -23,8 +23,8 @@ git:
                 end: "18:00"
           deployment:
             local: false
-            online: false
-            matchingLabel: true 
+            online: true
+            matchingLabel: false 
         - url: https://github.com/fxiang1/app-samples.git
           username: ""
           token: ""
@@ -33,7 +33,7 @@ git:
           deployment:
             local: false
             online: false
-            matchingLabel: true                   
+            matchingLabel: true 
 objectstore:
   data:
     - enable: true
@@ -96,7 +96,6 @@ helm:
             local: false
             online: false
             matchingLabel: true
-
     - enable: true
       name: ui-helm2
       type: helm
@@ -105,5 +104,6 @@ helm:
           chartName: airstrike
           deployment:
             local: false
-            online: false
-            matchingLabel: true            
+            online: true
+            matchingLabel: false            
+                  

--- a/tests/cypress/tests/02-validate/01-validate-ui-app-table.spec.js
+++ b/tests/cypress/tests/02-validate/01-validate-ui-app-table.spec.js
@@ -4,8 +4,12 @@
 
 const config = JSON.parse(Cypress.env("TEST_CONFIG"));
 import { validateResourceTable } from "../../views/application";
+import { getNumberOfManagedClusters } from "../../views/resources";
 
 describe("Application Validation Test for applications table", () => {
+  it(`get the number of the managed OCP clusters`, () => {
+    getNumberOfManagedClusters();
+  });
   for (const type in config) {
     const apps = config[type].data;
     apps.forEach(data => {
@@ -13,7 +17,8 @@ describe("Application Validation Test for applications table", () => {
         it(`Verify application ${
           data.name
         } info from applications table - ${type}: ${data.name}`, () => {
-          validateResourceTable(data.name, data);
+          const numberOfRemoteClusters = Cypress.env("numberOfManagedClusters");
+          validateResourceTable(data.name, data, numberOfRemoteClusters);
         });
       } else {
         it(`disable validation on resource ${type}`, () => {

--- a/tests/cypress/tests/03-edit/01-edit-application.spec.js
+++ b/tests/cypress/tests/03-edit/01-edit-application.spec.js
@@ -11,7 +11,9 @@ describe("Edit application Test", () => {
     const apps = config[type].data;
     apps.forEach(data => {
       if (data.enable) {
-        it(`Verify that ${data.name} is editable`, () => {
+        it(`Verify that ${
+          data.name
+        } is editable and can delete first subscription when multiple set`, () => {
           editApplication(data.name, data);
         });
         it(`Verify that ${data.name} is valid after edit`, () => {


### PR DESCRIPTION
epic https://github.com/open-cluster-management/backlog/issues/6248
https://github.com/open-cluster-management/backlog/issues/6620

Changes:
Deploy to all online clusters and check in the apps table the nb of clusters matches as expected
If the Deploy to all online clusters is set, don't check the existence of the cluster node by type ( we check if the node with type=remoteClusterName is created ). This is because the cluster node includes now all remote clusters so the type is no longer matching one cluster only )