### PR TITLE
add space for link

### DIFF
--- a/src-web/components/Topology/viewer/helpers/linkHelper.js
+++ b/src-web/components/Topology/viewer/helpers/linkHelper.js
@@ -530,7 +530,10 @@ export const counterZoomLinks = (svg, currentZoom, showLineLabels) => {
     if (showLineLabels) {
       const fontSize = counterZoom(currentZoom.k, 0.2, 0.85, 10, 20)
       const labels = svg.select('g.links').selectAll('g.label')
-      labels.selectAll('text.linkText').style('font-size', fontSize + 'px')
+      labels
+        .selectAll('text.linkText')
+        .style('font-size', fontSize + 'px')
+        .attr('dy', -2)
     }
   }
 }


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/5792
- added the space for the texts on the links

Before:
![image](https://user-images.githubusercontent.com/26282541/98024070-c4af6280-1dd5-11eb-8da6-bd625b8c1bfc.png)


After:
![image](https://user-images.githubusercontent.com/26282541/98024013-b5c8b000-1dd5-11eb-8d66-daca7b0ed668.png)
