### PR TITLE
fix display for leaves

### DIFF
--- a/src-web/components/Topology/viewer/helpers/nodeHelper.js
+++ b/src-web/components/Topology/viewer/helpers/nodeHelper.js
@@ -741,7 +741,7 @@ export const counterZoomLabels = (svg, currentZoom) => {
 
     ////////// LABELS //////////////////////////////
     let showClass, hideClass
-    if (s > 0.6) {
+    if (s > 0.4) {
       showClass = 'regularLabel'
       hideClass = 'compactLabel'
     } else {

--- a/src-web/components/Topology/viewer/layouts/application.js
+++ b/src-web/components/Topology/viewer/layouts/application.js
@@ -28,7 +28,12 @@ export const getConnectedApplicationLayoutOptions = (
     .toArray()
   const leaves = nodes.leaves()
   positionApplicationRows(roots, typeToShapeMap)
-  if (nodes.length < 40 && roots.length === 1 && leaves.length > 2) {
+  if (
+    nodes.length < 40 &&
+    roots.length === 1 &&
+    leaves.length > 2 &&
+    leaves.length < 20
+  ) {
     return {
       name: 'preset'
     }


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/3999

- changed the display for topology if  the number of leaves are greater than 20
- also shows the resource info when the page is rendered

Before:
![image](https://user-images.githubusercontent.com/26282541/98293349-26113600-1f7c-11eb-8d4a-c91b993becd8.png)

With the change:
![image](https://user-images.githubusercontent.com/26282541/98293445-55c03e00-1f7c-11eb-8029-129f2e330ab4.png)
