### PR TITLE
Prevent next button from going to the next subscription

### DIFF
--- a/src-web/components/Topology/viewer/ChannelControl.js
+++ b/src-web/components/Topology/viewer/ChannelControl.js
@@ -231,7 +231,7 @@ class ChannelControl extends React.Component {
       const { channelMap } = this.state
       const channelKeys = Object.keys(channelMap)
       let currentChannelMap = {}
-      for (var i = 0; i < channelKeys.length; i++) {
+      for (let i = 0; i < channelKeys.length; i++) {
         const channelSubscription = this.getChannelSubscription(
           channelKeys[i]
         )


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/6905

Changed the next button to not go to the next subscription and also the last button to do the same.