### PR TITLE
fix cypress login idp user

### DIFF
--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -238,27 +238,41 @@ Cypress.Commands.add("logInAsRole", role => {
   // Cypress.env("OC_CLUSTER_PASS",Cypress.env("OC_CLUSTER_USER_PASS"))
   Cypress.env("OC_IDP", idp);
 
-  // login only if user is not looged In
   cy.visit("/multicloud/applications");
-  cy.get("body").then(body => {
-    // Check if logged in
-    if (body.find("#header").length === 0) {
-      // Check if identity providers are configured
-      if (body.find("form").length === 0) cy.contains(idp).click();
-      cy
-        .get("#inputUsername", { timeout: 20000 })
-        .click()
-        .focused()
-        .type(user);
-      cy
-        .get("#inputPassword", { timeout: 20000 })
-        .click()
-        .focused()
-        .type(password);
-      cy.get('button[type="submit"]', { timeout: 20000 }).click();
-      cy.get("#header", { timeout: 30000 }).should("exist");
-    }
+  cy.get(".header-user-info-dropdown_icon").then($btn => {
+    //logout when test starts since we need to use the app idp user
+    cy.log("Logging out existing user");
+    cy.get($btn).click();
+    cy.contains("Log out").click();
+    // cy.clearCookies()
   });
+
+  cy.log(`Attempt to log in app app tests user ${user} with idp ${idp}`);
+  cy
+    .get(".pf-c-login__main-body")
+    .get(".pf-c-button")
+    .each($el => {
+      const userIDP = $el.text();
+      if (userIDP == idp) {
+        cy
+          .get($el)
+          .focus()
+          .click({ force: true });
+
+        cy
+          .get("#inputUsername", { timeout: 20000 })
+          .click()
+          .focused()
+          .type(user);
+        cy
+          .get("#inputPassword", { timeout: 20000 })
+          .click()
+          .focused()
+          .type(password);
+        cy.get('button[type="submit"]', { timeout: 20000 }).click();
+        cy.get("#header", { timeout: 30000 }).should("exist");
+      }
+    });
 });
 
 Cypress.Commands.add("logoutFromRole", role => {


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/7205

The fix addressed here : 
When app tests start running, if there is a login session, the login user is logged out and log in again as the app RBAC test user. This part was not functioning correctly

Another issue that needs to be addressed by the CICD team: 
- app tests cannot be run in parallel with any other tests because they are using a different RBAC user .. so if I login with the app tests then all other tests are also using my user ( unless they log us out to login with their own user ; this is what the app ui does )
- Search and cluster squads are still using  kubeadmin for their UI tests; this could be why app tests are not behaving well when executed in parallel with the rest
