### PR TITLE
invalid input, verify save works as expected

### DIFF
--- a/tests/cypress/views/common.js
+++ b/tests/cypress/views/common.js
@@ -91,6 +91,8 @@ export const submitSave = successState => {
       .should("include", `${name}`);
   } else {
     notification.shouldExist("error", { timeout: 2 * 1000 });
+    cy.log("Verify Save button is disabled");
+    modal.shouldBeDisabled();
   }
 };
 
@@ -221,7 +223,11 @@ export const notification = {
   shouldExist: type =>
     cy
       .get(`.bx--inline-notification[kind="${type}"]`, { timeout: 200 * 1000 })
-      .should("exist")
+      .should("exist"),
+  shouldNotExist: type =>
+    cy
+      .get(`.bx--inline-notification[kind="${type}"]`, { timeout: 200 * 1000 })
+      .should("not.exist")
 };
 
 export const resourcePage = {
@@ -647,6 +653,14 @@ export const validateSubscriptionDetails = (name, data, type, opType) => {
   }
 };
 
+const saveErrorShouldNotExist = () => {
+  cy.log("Verify Save errors are gone");
+  cy
+    .get("#notifications", { timeout: 50 * 1000 })
+    .scrollIntoView({ offset: { top: -500, left: 0 } });
+  notification.shouldNotExist("error", { timeout: 2 * 1000 }); //save error goes away
+};
+
 export const testInvalidApplicationInput = () => {
   const validURL = "http://a.com";
   const invalidValue = "INVALID VALUE";
@@ -657,14 +671,26 @@ export const testInvalidApplicationInput = () => {
   cy.get("[data-test-create-application=true]", { timeout: 50 * 1000 }).click();
   cy.get(".bx--detail-page-header-title-container").should("exist");
 
+  //enter a valid ns
+  cy
+    .get("#namespace", { timeout: 50 * 1000 })
+    .click()
+    .clear()
+    .type("default")
+    .blur();
+
   cy.log("Test invalid name");
   cy.get("#name", { timeout: 50 * 1000 }).type(invalidValue);
   cy.get("#name-error-msg").should("exist");
+
+  submitSave(false); //test save error
+
   cy
     .get("#name", { timeout: 50 * 1000 })
     .clear()
     .type(validValue);
   cy.get("#name-error-msg").should("not.exist");
+  saveErrorShouldNotExist(); //save error goes away
 
   cy.log("Test invalid namespace");
   cy
@@ -672,6 +698,8 @@ export const testInvalidApplicationInput = () => {
     .type(invalidValue)
     .blur();
   cy.get("[data-invalid=true]", { timeout: 2 * 1000 }).should("exist");
+  submitSave(false); //test save error
+
   cy
     .get("#namespace", { timeout: 50 * 1000 })
     .click()
@@ -679,6 +707,7 @@ export const testInvalidApplicationInput = () => {
     .type("default")
     .blur();
   cy.get("[data-invalid=true]").should("not.exist");
+  saveErrorShouldNotExist(); //save error goes away
 
   cy.log("Test invalid git url");
   cy
@@ -686,15 +715,18 @@ export const testInvalidApplicationInput = () => {
     .click({ force: true })
     .trigger("mouseover");
 
-  cy.get("#labelName-0-clusterSelector").type("label");
-  cy.get("#labelValue-0-clusterSelector").type("value");
-
   cy
     .get("#githubURL", { timeout: 20 * 1000 })
     .type(invalidValue)
     .blur();
+  //enter a valid deployment value
+  cy.get("#labelName-0-clusterSelector").type("label");
+  cy.get("#labelValue-0-clusterSelector").type("value");
+
   cy.get("[data-invalid=true]").should("exist");
   cy.wait(1000);
+  submitSave(false); //test save error
+
   cy
     .get("#githubURL", { timeout: 20 * 1000 })
     .click()
@@ -702,6 +734,7 @@ export const testInvalidApplicationInput = () => {
     .type(validURL)
     .blur();
   cy.get("[data-invalid=true]").should("not.exist");
+  saveErrorShouldNotExist(); //save error goes away
 
   cy
     .get("#githubBranch", { timeout: 20 * 1000 })
@@ -716,6 +749,7 @@ export const testInvalidApplicationInput = () => {
     .type(validValue)
     .blur();
   cy.get("[data-invalid=true]").should("not.exist");
+  saveErrorShouldNotExist(); //save error goes away
 
   cy.log("Test invalid HELM url");
   cy
@@ -728,15 +762,19 @@ export const testInvalidApplicationInput = () => {
     .click()
     .trigger("mouseover");
 
-  cy.get("#labelName-0-clusterSelector").type("label");
-  cy.get("#labelValue-0-clusterSelector").type("value");
-
   cy
     .get("#helmURL", { timeout: 20 * 1000 })
     .type(invalidValue)
     .blur();
+  //enter a valid deployment value and a chart name
+  cy.get("#labelName-0-clusterSelector").type("label");
+  cy.get("#labelValue-0-clusterSelector").type("value");
+  cy.get("#helmChartName").type("chartName");
+
   cy.get("[data-invalid=true]").should("exist");
   cy.wait(1000);
+  submitSave(false); //test save error
+
   cy
     .get("#helmURL", { timeout: 20 * 1000 })
     .click()
@@ -744,6 +782,7 @@ export const testInvalidApplicationInput = () => {
     .type(validURL)
     .blur();
   cy.get("[data-invalid=true]").should("not.exist");
+  saveErrorShouldNotExist(); //save error goes away
 
   cy.log("Test invalid object store url");
   cy
@@ -755,15 +794,18 @@ export const testInvalidApplicationInput = () => {
     .click()
     .trigger("mouseover");
 
-  cy.get("#labelName-0-clusterSelector").type("label");
-  cy.get("#labelValue-0-clusterSelector").type("value");
-
   cy
     .get("#objectstoreURL", { timeout: 20 * 1000 })
     .type(invalidValue)
     .blur();
+  //enter a valid deployment value
+  cy.get("#labelName-0-clusterSelector").type("label");
+  cy.get("#labelValue-0-clusterSelector").type("value");
+
   cy.get("[data-invalid=true]").should("exist");
   cy.wait(1000);
+  submitSave(false); //test save error
+
   cy
     .get("#objectstoreURL", { timeout: 20 * 1000 })
     .click()
@@ -771,6 +813,7 @@ export const testInvalidApplicationInput = () => {
     .type(validURL)
     .blur();
   cy.get("[data-invalid=true]").should("not.exist");
+  saveErrorShouldNotExist(); //save error goes away
 
   cy.log("Test invalid time window");
   const timeWindow = {
@@ -779,8 +822,7 @@ export const testInvalidApplicationInput = () => {
     date: []
   };
   selectTimeWindow(timeWindow, 0);
-
-  submitSave(false);
+  submitSave(false); //test error
 };
 
 // Calculates unique CSS selectors based on index


### PR DESCRIPTION
https://github.com/open-cluster-management/application-ui/blob/master/tests/cypress/tests/01-create/01-invalid-tests.spec.js 

For invalid input tests verify :
- opens create app editor
- fills in invalid name, namespace and verify UI errors
- click Save action ; verify save throws and error and Save action becomes disabled

==
- create Git subscription
- input invalid git Url, branch, timewindow..
- verify UI errors after each invalid input
- click Save action  after each invalid input; verify save throws a notification error and Save action becomes disabled

==
- add on the same app a Helm subscription
- input invalid helm Url, timewindow..
- verify UI errors after each invalid input
- click Save action  after each invalid input; verify save throws and error and Save action becomes disabled

==
- add on the same page an object store subscription
- input invalid store Url, timewindow..
- verify UI errors after each invalid input
- click Save action  after each invalid input; verify save throws and error and Save action becomes disabled

==
After each of the above steps, inputs a valid value
- validates no errors in the UI

https://polarion.engineering.redhat.com/polarion/#/project/RHACM4K/workitems?query=caseautomation.KEY%3Anotautomated%20AND%20(TEST_RECORDS%3A(RHACM4K%2FACM21AutoAppLC))