### PR TITLE
update rbac timeout failure

### DIFF
--- a/tests/cypress/support/useradd.js
+++ b/tests/cypress/support/useradd.js
@@ -126,7 +126,7 @@ Cypress.Commands.add("addUserIfNotCreatedBySuite",() => {
             cy.deleteExistingUsersIdentity()
             cy.addUsers();
             cy.getIdentity();
-            cy.wait(20000)  // Wait for users to take affect
+            cy.wait(60000)  // Wait for users to take affect
             cy.addRolesToManagedClusterUser()
         }
         else cy.log("Users Already initiated by Testsuite")


### PR DESCRIPTION
Updated RBAC Wait to 60 seconds for users and IDP to take effect.