### PR TITLE
change Alert to AcmAlert in single app page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1939,11 +1939,12 @@
       }
     },
     "@open-cluster-management/ui-components": {
-      "version": "0.1.78",
-      "resolved": "https://registry.npmjs.org/@open-cluster-management/ui-components/-/ui-components-0.1.78.tgz",
-      "integrity": "sha512-FeVMIoIiQnhmtyg1oRJ4SpsYq7WIhIZxBPP2mgNW5Jvt+9RtNaWGqRs8wlemu+aWx9metEGkeDrPizh5rieadw==",
+      "version": "0.1.89",
+      "resolved": "https://registry.npmjs.org/@open-cluster-management/ui-components/-/ui-components-0.1.89.tgz",
+      "integrity": "sha512-fmrtC20/89mSZxR40FG/kCXfnvf5vIG0OmrbXWJrGyNUnUJlJllwdQ2n08viEj6TUrJJkbPkQBOjBC9d3+p7SQ==",
       "requires": {
         "@material-ui/styles": "^4.10.0",
+        "@patternfly/react-charts": "^6.12.2",
         "@patternfly/react-core": "^4.75.2",
         "@patternfly/react-table": "^4.19.5",
         "fuse.js": "^6.4.3",
@@ -2028,6 +2029,55 @@
       "version": "4.65.5",
       "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.65.5.tgz",
       "integrity": "sha512-10dXyBt4fo55Wtm7v+Vmn9eVp4rD25fR296uif0nxGX3ZXhEuyyPOfo2DgNmCFHu42Exo6N8DP7W472Pp9VkJw=="
+    },
+    "@patternfly/react-charts": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.12.2.tgz",
+      "integrity": "sha512-fvRTZfJBYrVUtr2zQEKCqlHz6zn2GLnwKJ1bg+vqbzza160KVhe63Lklul85/1nfAgmMlBYq8PCjOt32kVCDew==",
+      "requires": {
+        "@patternfly/patternfly": "4.65.5",
+        "@patternfly/react-styles": "^4.7.16",
+        "@patternfly/react-tokens": "^4.9.18",
+        "hoist-non-react-statics": "^3.3.0",
+        "lodash": "^4.17.19",
+        "tslib": "1.13.0",
+        "victory": "^35.3.5",
+        "victory-area": "^35.2.0",
+        "victory-axis": "^35.2.0",
+        "victory-bar": "^35.2.0",
+        "victory-chart": "^35.2.0",
+        "victory-core": "^35.2.0",
+        "victory-create-container": "^35.2.0",
+        "victory-group": "^35.2.0",
+        "victory-legend": "^35.2.0",
+        "victory-line": "^35.2.0",
+        "victory-pie": "^35.2.0",
+        "victory-scatter": "^35.2.0",
+        "victory-stack": "^35.2.0",
+        "victory-tooltip": "^35.2.0",
+        "victory-voronoi-container": "^35.2.0",
+        "victory-zoom-container": "^35.2.0"
+      },
+      "dependencies": {
+        "@patternfly/react-styles": {
+          "version": "4.7.16",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.7.16.tgz",
+          "integrity": "sha512-bJmRrYKXgHGPPwLHg/gy1tDb/qEV6JpFLgkelLuz38czXeBnPpAUn9yKry3wNr95VQGERT6FcLsWjXKPY1x42Q=="
+        },
+        "@patternfly/react-tokens": {
+          "version": "4.9.18",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.9.18.tgz",
+          "integrity": "sha512-zQfqwKtoz1hDngyiGnF6oHeESDtgNY6C79Db97JxMMuRBV7i+5f6uC/DrYhcqNtqHA7mxrVJg0SM1xnPSAW9lA=="
+        },
+        "hoist-non-react-statics": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        }
+      }
     },
     "@patternfly/react-core": {
       "version": "4.75.2",
@@ -7928,6 +7978,19 @@
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
+      }
+    },
+    "delaunator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
+    },
+    "delaunay-find": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.5.tgz",
+      "integrity": "sha512-7yAJ/wmKWj3SgqjtkGqT/RCwI0HWAo5YnHMoF5nYXD8cdci+YSo23iPmgrZUNOpDxRWN91PqxUvMMr2lKpjr+w==",
+      "requires": {
+        "delaunator": "^4.0.0"
       }
     },
     "delayed-stream": {
@@ -20579,6 +20642,11 @@
         }
       }
     },
+    "react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -25732,6 +25800,340 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "victory": {
+      "version": "35.4.2",
+      "resolved": "https://registry.npmjs.org/victory/-/victory-35.4.2.tgz",
+      "integrity": "sha512-f0WV2fP18l4Xiactb+2+Tidrgc035o9KGvcedx2PQ2OnJfxnwJ1G+UHJISRi/IjR64lRTIdMJik1HI+j4nYKRA==",
+      "requires": {
+        "victory-area": "^35.4.1",
+        "victory-axis": "^35.4.1",
+        "victory-bar": "^35.4.1",
+        "victory-box-plot": "^35.4.1",
+        "victory-brush-container": "^35.4.1",
+        "victory-brush-line": "^35.4.1",
+        "victory-candlestick": "^35.4.1",
+        "victory-chart": "^35.4.1",
+        "victory-core": "^35.4.1",
+        "victory-create-container": "^35.4.2",
+        "victory-cursor-container": "^35.4.1",
+        "victory-errorbar": "^35.4.1",
+        "victory-group": "^35.4.1",
+        "victory-histogram": "^35.4.1",
+        "victory-legend": "^35.4.1",
+        "victory-line": "^35.4.1",
+        "victory-pie": "^35.4.1",
+        "victory-polar-axis": "^35.4.1",
+        "victory-scatter": "^35.4.1",
+        "victory-selection-container": "^35.4.1",
+        "victory-shared-events": "^35.4.1",
+        "victory-stack": "^35.4.1",
+        "victory-tooltip": "^35.4.2",
+        "victory-voronoi": "^35.4.1",
+        "victory-voronoi-container": "^35.4.2",
+        "victory-zoom-container": "^35.4.1"
+      }
+    },
+    "victory-area": {
+      "version": "35.4.1",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-35.4.1.tgz",
+      "integrity": "sha512-+FV39ey/w8GZO35XXge8PIFYLEphkHypN0qWvlwChtyQDXwsbdcAiG7qBLtZuOOR47phDvBPC75w3YFE1XYarQ==",
+      "requires": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.1"
+      }
+    },
+    "victory-axis": {
+      "version": "35.4.1",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-35.4.1.tgz",
+      "integrity": "sha512-zQgakJCK4nQbYVelj4vj9AEyZHx7I/EKwGKOlwgkzrTsdzhs7QV2W0PK0LMXvgw+7QLQjmcQ52OvU17KU8Jklg==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.1"
+      }
+    },
+    "victory-bar": {
+      "version": "35.4.1",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-35.4.1.tgz",
+      "integrity": "sha512-G1qEzCcu4el6ulUNEjSNktG+wdG8Rc9HdoUbp7ZVA97PVtZdmYMvV/uTur+QptuGjiOEL9p3AFrLJ7jxegCzgg==",
+      "requires": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.1"
+      }
+    },
+    "victory-box-plot": {
+      "version": "35.4.1",
+      "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-35.4.1.tgz",
+      "integrity": "sha512-jyGSjvOTnwZ9N8LmDvF2aUCdWZNjoyzXElj+TpRZ243CCdBjZWBYx7E5jhLkqwQ6t7U72ONJzq/aatl6NZjuuw==",
+      "requires": {
+        "d3-array": "^1.2.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.1"
+      }
+    },
+    "victory-brush-container": {
+      "version": "35.4.1",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-35.4.1.tgz",
+      "integrity": "sha512-CBfvPtcl8riFlNVbjCcWNhp60hK8FoQqh/dR5YWy0HftZVTscSvTweLTvUwHAtKFhygA9U1H4AJvgrjrw7UHOQ==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.4.1"
+      }
+    },
+    "victory-brush-line": {
+      "version": "35.4.1",
+      "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-35.4.1.tgz",
+      "integrity": "sha512-3jwwloQMBZA33sq+JXTjVm3p4lN1RHfnIcP+8jB+vhsmveU5wfbvbW+yh2ew9wn/cmQUTgWH/ebq8UErG5uSWA==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.4.1"
+      }
+    },
+    "victory-candlestick": {
+      "version": "35.4.1",
+      "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-35.4.1.tgz",
+      "integrity": "sha512-ocJHEF4D/m6hrb8ngDLq8177kC+4HdQ1haSdWaXIuMO1PLERmr9F1e/bh1ftzOeuGZ38egC1D8pblIFFJYFgZA==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.1"
+      }
+    },
+    "victory-chart": {
+      "version": "35.4.1",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-35.4.1.tgz",
+      "integrity": "sha512-K6ZZ+xe1iavIOEl3acErmznObJk2eQY3bUeczyrbLKiuATSsDDWHlB5ZBTbgDQKk6OrDF1bl+AlvyBJxB2wGIA==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-axis": "^35.4.1",
+        "victory-core": "^35.4.1",
+        "victory-polar-axis": "^35.4.1",
+        "victory-shared-events": "^35.4.1"
+      }
+    },
+    "victory-core": {
+      "version": "35.4.1",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-35.4.1.tgz",
+      "integrity": "sha512-TEdtJyU0J7xiNybjEzX5R6fiZOwYbJUd72xnw8pttpQaBl432fin7g1ytsbsS4EH+J5xa2fcPuOqPCfdidvo6A==",
+      "requires": {
+        "d3-ease": "^1.0.0",
+        "d3-interpolate": "^1.1.1",
+        "d3-scale": "^1.0.0",
+        "d3-shape": "^1.2.0",
+        "d3-timer": "^1.0.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0"
+      }
+    },
+    "victory-create-container": {
+      "version": "35.4.2",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-35.4.2.tgz",
+      "integrity": "sha512-yBh7GY6UFqsfLfel4tJp9nC9zukuqjO7gGWfD1ausVTeJC9U/V3C/lezgpu/MXI+Mbw2v3Mso2SWSG2+twTqNg==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "victory-brush-container": "^35.4.1",
+        "victory-core": "^35.4.1",
+        "victory-cursor-container": "^35.4.1",
+        "victory-selection-container": "^35.4.1",
+        "victory-voronoi-container": "^35.4.2",
+        "victory-zoom-container": "^35.4.1"
+      }
+    },
+    "victory-cursor-container": {
+      "version": "35.4.1",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-35.4.1.tgz",
+      "integrity": "sha512-+xiHZGg6U0nl5+L02/uX3A7RUP//4nY6898c+bp0XiIFFHAM9tgwqX1YA8yi5D4Sbo7L7Xi2RBxQRBksYymC4g==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.1"
+      }
+    },
+    "victory-errorbar": {
+      "version": "35.4.1",
+      "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-35.4.1.tgz",
+      "integrity": "sha512-PKLthmptsZaXZEhHAi16ubF9LqzN82l4GmLLFh4yXiQWkwG1HbmC6ljeakui2pOi+hiLo1UBtX2e64GDjqhyrw==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.1"
+      }
+    },
+    "victory-group": {
+      "version": "35.4.1",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-35.4.1.tgz",
+      "integrity": "sha512-0EWenPEmOcpww8Z8DrSxPn9jWusWwWc/ERee06ahP/ElgeYwYQqcuyrdxuW3YEgjeS0DGN9R6xPYBfo9/91qkQ==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.4.1",
+        "victory-shared-events": "^35.4.1"
+      }
+    },
+    "victory-histogram": {
+      "version": "35.4.1",
+      "resolved": "https://registry.npmjs.org/victory-histogram/-/victory-histogram-35.4.1.tgz",
+      "integrity": "sha512-YfaQPdew8KE7yTtYKtBJb9BtHsH2I56iL0Ikwtvem/Xl11aPvjlFf/mGMwoUE3rS8WSl2NgrN4lGm+SAQKkDOQ==",
+      "requires": {
+        "d3-array": "^2.4.0",
+        "d3-scale": "^1.0.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-bar": "^35.4.1",
+        "victory-core": "^35.4.1"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+          "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+        }
+      }
+    },
+    "victory-legend": {
+      "version": "35.4.1",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-35.4.1.tgz",
+      "integrity": "sha512-Wq8rvzNX7GrgNIhOY9sO6Z3aehhNZo8J8uV1KqzF9lPwj5aK+0RosXCqnTGWTe44gBk5J/c/YqEYhgnIFwDf5A==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.1"
+      }
+    },
+    "victory-line": {
+      "version": "35.4.1",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-35.4.1.tgz",
+      "integrity": "sha512-pd4uRffcP9NnWkz2MNW2XyLv9Mqh+p941Kpyavu2cX7rzj4PvicJzjFR9KU/rh+B0rkzkN8SY1sOGbe7vnL/Rw==",
+      "requires": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.1"
+      }
+    },
+    "victory-pie": {
+      "version": "35.4.1",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-35.4.1.tgz",
+      "integrity": "sha512-WfpkfR8V0ArVI286DRvJCVyIhllGNEMajjKKBVULCWuNnaW4nbF/sXw2689kT0tDZC9FHVFjlj3wLs3i32bBJQ==",
+      "requires": {
+        "d3-shape": "^1.0.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.1"
+      }
+    },
+    "victory-polar-axis": {
+      "version": "35.4.1",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-35.4.1.tgz",
+      "integrity": "sha512-tqSV6ojrkfvcN4+JzNTSznP1Ogug2kEYP88g/3W7uyfraNs+XdF67e1BY9IA/INyAVm86PDgkQwn1EvSDt0ZVA==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.1"
+      }
+    },
+    "victory-scatter": {
+      "version": "35.4.1",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-35.4.1.tgz",
+      "integrity": "sha512-GPBYPkiZTtw7F09DVp/ksmsVHhnbyXYc97mQWkuROM7zhvPDbBVFjWR9kRv0ldlD5TA40RCJJaqM6qkJHQoLTQ==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.1"
+      }
+    },
+    "victory-selection-container": {
+      "version": "35.4.1",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-35.4.1.tgz",
+      "integrity": "sha512-9XilYYaGnstjDHCthWs0WAf0I9zVH3dmfXqwBJKOYG7UnZfR4KW39G6Vf3JPZE6Wmk1iXnYZZPuA8I8hdiIQng==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.1"
+      }
+    },
+    "victory-shared-events": {
+      "version": "35.4.1",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-35.4.1.tgz",
+      "integrity": "sha512-ye0/Ey4TCsupjhyB66YzkVYBxPDUZWC8r4cLjj/gkCL5M6G/Udl4c68J6vT56djYjzsNp21URYZlLUyNshpfUw==",
+      "requires": {
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.4.1"
+      }
+    },
+    "victory-stack": {
+      "version": "35.4.1",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-35.4.1.tgz",
+      "integrity": "sha512-0BKlg18mbmH30P+cAk0FtEvIfDrg3Z50td4EA8UXo4Ty492aUcQ5Ejx+x9+o7lK6WjgfITIF9FV1JnQ2/OhM4A==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.4.1",
+        "victory-shared-events": "^35.4.1"
+      }
+    },
+    "victory-tooltip": {
+      "version": "35.4.2",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-35.4.2.tgz",
+      "integrity": "sha512-OmGTStuN3Dwxm6k4wm70rVC7ZMJ8PnhmOR5uWY3Jfut2Pi+roSpFDe2+URkwC8MItdcx68mqRC4zK3AnCetc8A==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.1"
+      }
+    },
+    "victory-voronoi": {
+      "version": "35.4.1",
+      "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-35.4.1.tgz",
+      "integrity": "sha512-m0d/EhJD/Bm/WOHYXQgVUFjaqWIYXJef0ku6Pgrx2ZiCaijS72+wM0FHA9djiTkXCvPIbmwEGZ5sAxrqafmaDw==",
+      "requires": {
+        "d3-voronoi": "^1.1.2",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.1"
+      }
+    },
+    "victory-voronoi-container": {
+      "version": "35.4.2",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-35.4.2.tgz",
+      "integrity": "sha512-CMoxelrmaILqG75RP3lir6lIwz1ltWxYbNJZrG/YyyYi3oMl5niF8IvwHA4gdqTPSdwbZHMuTfytD6itSWoRrg==",
+      "requires": {
+        "delaunay-find": "0.0.5",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^35.4.1",
+        "victory-tooltip": "^35.4.2"
+      }
+    },
+    "victory-zoom-container": {
+      "version": "35.4.1",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-35.4.1.tgz",
+      "integrity": "sha512-Qz/57YeFCE1NGGIAo/FgN/4VhEwo2AmtriqAfhJMw5WNe8sDRBmcnIAhqM8IF/N+f3OnkEDJ5cUrPYB2T7DBMA==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^35.4.1"
       }
     },
     "vm-browserify": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "author": "",
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
-    "@open-cluster-management/ui-components": "^0.1.78",
+    "@open-cluster-management/ui-components": "^0.1.89",
     "@patternfly/react-core": "^4.75.2",
     "@patternfly/react-icons": "^4.7.4",
     "@patternfly/react-tokens": "2.8.13",

--- a/src-web/components/common/OverviewCards/index.js
+++ b/src-web/components/common/OverviewCards/index.js
@@ -99,13 +99,7 @@ class OverviewCards extends React.Component {
         'err.message',
         msgs.get('resource.error')
       )
-      return (
-        <AcmAlert
-          variant="danger"
-          title={errMessage}
-          className="overview-notification"
-        />
-      )
+      return <AcmAlert variant="danger" title={errMessage} noClose />
     }
     if (HCMApplicationList.status === REQUEST_STATUS.NOT_FOUND) {
       const infoMessage = _.get(
@@ -113,13 +107,7 @@ class OverviewCards extends React.Component {
         'err.err',
         msgs.get('load.app.info.notfound', [selectedAppName])
       )
-      return (
-        <AcmAlert
-          variant="info"
-          title={infoMessage}
-          className="overview-notification"
-        />
-      )
+      return <AcmAlert variant="info" title={infoMessage} noClose />
     }
 
     const toggleAccordion = toggleStatus => {

--- a/src-web/components/common/OverviewCards/style.scss
+++ b/src-web/components/common/OverviewCards/style.scss
@@ -185,6 +185,12 @@
   }
 }
 
-.overview-notification {
+.pf-c-alert {
   margin: 0.5rem 0;
+
+  .pf-c-alert__title,
+  .pf-c-alert__description > p {
+    font-size: 14px;
+    margin-top: auto;
+  }
 }


### PR DESCRIPTION
After speaking with Kevin we decided to go with noClose in this case since there's no content if the user closes the Alert. 

Styling add-ons
- reduce font size to match PF storybook
- vertically centre the title

<img width="1429" alt="Screen Shot 2020-12-02 at 4 38 04 PM" src="https://user-images.githubusercontent.com/39634227/100934708-26d6b280-34bd-11eb-8a24-af104837cfd1.png">
<img width="1429" alt="Screen Shot 2020-12-02 at 4 38 33 PM" src="https://user-images.githubusercontent.com/39634227/100934711-276f4900-34bd-11eb-9d4b-4d2dc0a64aa6.png">
