### PR TITLE
build-test-image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,5 +102,5 @@ jobs:
           make 
           make pipeline-manifest/update PIPELINE_MANIFEST_COMPONENT_SHA256=${TRAVIS_COMMIT} PIPELINE_MANIFEST_COMPONENT_REPO=${TRAVIS_REPO_SLUG} PIPELINE_MANIFEST_BRANCH=${TRAVIS_BRANCH}
           rm -rf pipeline
-          echo "Waiting 60s before publishing test image..." && sleep 60
+          echo "Waiting 120s before publishing test image..." && sleep 120
           make publish-test-image


### PR DESCRIPTION
https://coreos.slack.com/archives/CVAB9H3DE/p1607018778060200
issue: app-ui's component image and its test image collide in push

this fix:
-  these stages won't run in parallel
- bumps up sleep time for update

We'll have only three stages >>
![image](https://user-images.githubusercontent.com/26282541/101083765-05d49700-357b-11eb-9bbc-b88af8073c30.png)
