### PR TITLE
Updated rbac role for test users

### DIFF
--- a/tests/cypress/config/users.yaml
+++ b/tests/cypress/config/users.yaml
@@ -11,7 +11,7 @@ users:
   # As superuser in RHACM lke default cluster-admin         
   
   admin-managed-cluster: test-mngd-cluster-admin
-  #open-cluster-management:cluster-manager-admin / cluster-wide
+  # open-cluster-management:admin:managed-cluster-1  / cluster-wide
   #admin / namespace
 
   edit-managed-cluster: test-mngd-cluster-edit
@@ -23,7 +23,7 @@ users:
   # view / namespace
   # Binded to the managed-cluster-1 and its namspace
 
-  subscription-admin: test-subscripion-admin
+  subscription-admin: test-subscription-admin
   # open-cluster-management:subscription-admin / cluster-wide
 
   admin: test-admin

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -272,7 +272,7 @@ Cypress.Commands.add("logInAsRole", role => {
         if (text == users[role]) {
           cy.log(`Already Logged in as User $users[role]`);
         } else {
-          logout();
+          cy.logout();
           cy.wait(5000);
           cy.login(idp, user, password);
         }

--- a/tests/cypress/support/useradd.js
+++ b/tests/cypress/support/useradd.js
@@ -27,22 +27,40 @@ Cypress.Commands.add('addRolesToManagedClusterUser', () => {
     for ( const role in users){
         if (role == 'admin-managed-cluster') {  
             const cmdAddRole = `oc adm policy add-cluster-role-to-user \
-                                open-cluster-management:admin:${Cypress.env("managedCluster")} ${users[role]}`
+                                open-cluster-management:admin:${Cypress.env("managedCluster")} ${users[role]}| \
+                                oc policy add-role-to-user admin ${users[role]} -n ${Cypress.env("managedCluster")}`
             cy.log(cmdAddRole)
             cy.exec(cmdAddRole)
         }
         if (role == 'edit-managed-cluster') {
             const cmdAddRole = `oc adm policy add-cluster-role-to-user \
-                                open-cluster-management:view:${Cypress.env("managedCluster")} ${users[role]}`
+                                open-cluster-management:view:${Cypress.env("managedCluster")} ${users[role]}| \
+                                oc policy add-role-to-user edit ${users[role]} -n ${Cypress.env("managedCluster")}`
             cy.log(cmdAddRole)
             cy.exec(cmdAddRole)
     }
         if (role == 'view-managed-cluster') {
             const cmdAddRole = `oc adm policy add-cluster-role-to-user \
-                                open-cluster-management:view:${Cypress.env("managedCluster")} ${users[role]}`
+                                open-cluster-management:view:${Cypress.env("managedCluster")} ${users[role]}| \
+                                oc policy add-role-to-user view ${users[role]} -n ${Cypress.env("managedCluster")}`
             cy.log(cmdAddRole)
             cy.exec(cmdAddRole)
-        } 
+        }
+        if (role == 'admin') {
+            const cmdAddRole = `oc policy add-role-to-user admin ${users[role]} -n ${Cypress.env("managedCluster")}`
+            cy.log(cmdAddRole)
+            cy.exec(cmdAddRole)
+        }
+        if (role == 'edit') {
+            const cmdAddRole = `oc policy add-role-to-user edit ${users[role]} -n ${Cypress.env("managedCluster")}`
+            cy.log(cmdAddRole)
+            cy.exec(cmdAddRole)
+        }
+        if (role == 'view') {
+            const cmdAddRole = `oc policy add-role-to-user view ${users[role]} -n ${Cypress.env("managedCluster")}`
+            cy.log(cmdAddRole)
+            cy.exec(cmdAddRole)
+        }
     }
 })
 

--- a/tests/cypress/templates/rbac_yaml/e2e-rbac-clusterrolebinding.yaml
+++ b/tests/cypress/templates/rbac_yaml/e2e-rbac-clusterrolebinding.yaml
@@ -23,36 +23,51 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: test-edit-clusterrolebinding
+  namespace: default
 subjects:
 - kind: User
   name: test-edit
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: edit
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
+metadata:
+  name: test-admin-clusterrolebinding
+  namespace: default
+subjects:
+- kind: User
+  name: test-admin
+roleRef:
+  kind: Role
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
 metadata:
   name: test-view-clusterrolebinding
+  namespace: default
 subjects:
 - kind: User
   name: test-view
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: view
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: test-subscripion-admin-clusterrolebinding
+  name: test-subscription-admin-clusterrolebinding
 subjects:
 - kind: User
-  name: test-subscripion-admin
+  name: test-subscription-admin
 roleRef:
   kind: ClusterRole
   name: open-cluster-management:subscription-admin


### PR DESCRIPTION
1. Updated RBAC Role for users:

-  test-mngd-cluster-admin
     admin  / namespace
- edit-managed-cluster: test-mngd-cluster-edit
  open-cluster-management:view:managed-cluster-1 / cluster-wide
  edit / namespace
- view-managed-cluster: test-mngd-cluster-view
   open-cluster-management:view:managed-cluster-1 / cluster-wide
  view / namespace

Roles are related  to issue  https://github.com/open-cluster-management/backlog/issues/7672

2. Fixed minor issue of logout() to cy.logout()  in command.js file .

3. Fixed typo in subscription manager-user in user.yaml file.