### PR TITLE
use aggregated cluster info

### DIFF
--- a/src-web/components/common/ResourceOverview/utils.js
+++ b/src-web/components/common/ResourceOverview/utils.js
@@ -196,22 +196,6 @@ export const getSearchLinkForOneApplication = params => {
   return ''
 }
 
-const getClusterCount = node => {
-  let remoteClusterCount = 0
-  let localClusterDeploy = false
-  const clusterNames = _.get(node, 'specs.allClusters', [])
-
-  localClusterDeploy = clusterNames.indexOf('local-cluster') !== -1
-  remoteClusterCount = localClusterDeploy
-    ? clusterNames.length - 1
-    : clusterNames.length
-
-  return {
-    remoteCount: remoteClusterCount,
-    isLocal: localClusterDeploy
-  }
-}
-
 const getSubCardData = (subData, node) => {
   let resourceType = ''
   let resourcePath = ''
@@ -325,7 +309,10 @@ export const getAppOverviewCardsData = (
         _.get(node, 'type', '') === 'application' &&
         _.get(node, 'id').indexOf('--deployable') === -1
       ) {
-        clusterData = getClusterCount(node)
+        clusterData = _.get(node, 'specs.allClusters', {
+          isLocal: false,
+          remoteCount: 0
+        })
         // Get date and time of app creation
         creationTimestamp = getShortDateTime(
           node.specs.raw.metadata.creationTimestamp,

--- a/tests/jest/components/TestingData.js
+++ b/tests/jest/components/TestingData.js
@@ -1152,7 +1152,10 @@ export const topologyNoChannel = {
       namespace: "default",
       specs: {
         allChannels: [],
-        allClusters: ["val-cluster"],
+        allClusters: {
+          isLocal: false,
+          remoteCount: 1
+        },
         allSubscriptions: [
           {
             kind: "Subscription",
@@ -1538,7 +1541,11 @@ export const topology = {
       name: "mortgage-app",
       namespace: "default",
       specs: {
-        allClusters: ["aa"],
+        allChannels: [],
+        allClusters: {
+          isLocal: false,
+          remoteCount: 1
+        },
         allChannels: [
           {
             kind: "Channel",

--- a/tests/jest/config/platform-properties.json
+++ b/tests/jest/config/platform-properties.json
@@ -409,6 +409,8 @@
   "spec.subscr.timeWindow.title": "Time Window",
   "spec.subscr.timeWindow.type": "Time Window type",
   "spec.subscr.timeWindow": "Current window status is",
+  "specs.k8sJob.templateName": "Ansible Tower Job template name",
+  "specs.k8sJob.secretName": "Ansible Tower secret",
   "subscription.page.label.info": "Use the navigation to view the resources that are deployed by the selected subscription.",
   "subscription.page.label": "Resource nodes",
   "subscription.page.nb": "of {0}",


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/7733

Get cluster aggregated details instead of the list of cluster names - from app topology
<img width="1042" alt="Screen Shot 2020-12-21 at 1 25 43 PM" src="https://user-images.githubusercontent.com/43010150/102809498-13b65480-4390-11eb-9e1c-2d5289a62520.png">

