### PR TITLE
wait for table search to show up

### DIFF
--- a/tests/cypress/views/common.js
+++ b/tests/cypress/views/common.js
@@ -117,7 +117,11 @@ export const resourceTable = {
     this.getRow(name, key, timeout).should("not.exist");
   },
   searchTable: function(name) {
-    cy.get(".pf-c-search-input__text-input").type(name);
+    cy
+      .get(".pf-c-search-input__text-input", {
+        timeout: 30 * 10000
+      })
+      .type(name);
   },
   openRowMenu: function(name, key) {
     cy


### PR DESCRIPTION
To address this canary failure https://travis-ci.com/github/open-cluster-management/canary/jobs/464209872
https://s3.console.aws.amazon.com/s3/object/canary-results-integration?region=us-east-1&prefix=data/210361673/app-ui-b96d4caee7698cdb98317a4dede0e7153827904d-videos/03-edit/02-edit-application-delete-subs.spec.js.mp4

Wait for the search text to show

<img width="954" alt="Screen Shot 2020-12-23 at 10 23 12 AM" src="https://user-images.githubusercontent.com/43010150/103012007-e640e680-4508-11eb-881e-36eb329780d8.png">
