### PR TITLE
use non kubeadmin

### DIFF
--- a/tests/cypress/config/index.js
+++ b/tests/cypress/config/index.js
@@ -144,5 +144,6 @@ exports.getUsers = () => {
     users: userData.users,
     idp: userData.idp
   };
+  console.log("getUsers returns ", userList);
   return userList;
 };

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -254,12 +254,27 @@ Cypress.Commands.add("get$", selector => {
 });
 
 Cypress.Commands.add("ocLogin", role => {
+  cy.log(
+    `STEP 1 ocLogin with role=${role} ROLE MUST BE SET in users.yaml ( use KEY, not value from users.yaml!)`
+  );
   const { users } = Cypress.env("USER_CONFIG");
   let user;
   if (role !== "kubeadmin") {
     cy.addUserIfNotCreatedBySuite();
-    user = Cypress.env("OC_CLUSTER_USER", users[role]);
+    user = users[role];
+    if (!user) {
+      user = role;
+      cy.log(
+        `This user role was not found in users.yaml, try to recover and use the role as the user name`
+      );
+    }
+    Cypress.env("OC_CLUSTER_USER", user);
+    cy.log(
+      `Role is not kubeadmin, adding user=${user} to Cypress.env("OC_CLUSTER_USER"), which is the users[${role}]`
+    );
   }
+  cy.log("OC_CLUSTER_USER", Cypress.env("OC_CLUSTER_USER"));
+
   const loginUserDetails = {
     api: apiUrl,
     user: user || "kubeadmin",
@@ -280,6 +295,7 @@ Cypress.Commands.add("logInAsRole", role => {
 
   // Cypress.env("OC_CLUSTER_PASS",Cypress.env("OC_CLUSTER_USER_PASS"))
   Cypress.env("OC_IDP", idp);
+  cy.log(`logInAsRole, role=${role}, user=${user}, idp=${idp}`);
 
   // login only if user is not looged In
   const logInIfRequired = () => {
@@ -346,6 +362,9 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add("rbacSwitchUser", role => {
+  cy.log(
+    `rbacSwitchUser role=${role}, USER_CONFIG env=${Cypress.env("USER_CONFIG")}`
+  );
   const { users } = Cypress.env("USER_CONFIG");
   if (Cypress.config().baseUrl.includes("localhost")) {
     cy.ocLogin(role);

--- a/tests/cypress/support/index.js
+++ b/tests/cypress/support/index.js
@@ -38,7 +38,7 @@ Cypress.Cookies.defaults({
 
 before(() => {
   // Use kubeadmin user to install ansible operator
-  cy.ocLogin("kubeadmin");
+  cy.ocLogin(Cypress.env("OC_CLUSTER_USER"));
   cy.installAnsibleOperator();
   if (Cypress.config().baseUrl.includes("localhost")) {
     cy.ocLogin("cluster-manager-admin");


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/9102

Trying to use the logged in user if the user is not found in the roles.yaml set of users ( this would be a bootstrap user, but not kubeadmin )