### PR TITLE
Get resource name from label for multi helm deploys

### DIFF
--- a/src-web/components/Topology/utils/diagram-helpers.js
+++ b/src-web/components/Topology/utils/diagram-helpers.js
@@ -788,10 +788,12 @@ export const getNameWithoutChartRelease = (
     }
   }
 
-  if (!foundReleaseLabel && kind !== 'helmrelease') {
-    if (labelMap['app.kubernetes.io/name']) {
-      name = labelMap['app.kubernetes.io/name']
-    }
+  if (
+    !foundReleaseLabel &&
+    kind !== 'helmrelease' &&
+    labelMap['app.kubernetes.io/name']
+  ) {
+    name = labelMap['app.kubernetes.io/name']
   }
 
   return name


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/backlog/issues/9513

Add a check to get the resource name from labels if the deploy is helm release.
<img width="1550" alt="image" src="https://user-images.githubusercontent.com/38960034/108133095-fd700080-7081-11eb-962c-b76d642c5b88.png">
