### PR TITLE
move git path validation out of app create

### DIFF
--- a/tests/cypress/tests/01-create/01-wizard.spec.js
+++ b/tests/cypress/tests/01-create/01-wizard.spec.js
@@ -4,11 +4,7 @@
 
 const config = JSON.parse(Cypress.env("TEST_CONFIG"));
 import { createApplication } from "../../views/application";
-import {
-  getManagedClusterName,
-  channelsInformation
-} from "../../views/resources";
-import { getResourceKey, resourceTable } from "../../views/common";
+import { getManagedClusterName } from "../../views/resources";
 
 describe("Application UI: [P1][Sev1][app-lifecycle-ui] Application Creation Test", () => {
   it(`get the name of the managed OCP cluster`, () => {

--- a/tests/cypress/tests/01-create/02-invalid-tests.spec.js
+++ b/tests/cypress/tests/01-create/02-invalid-tests.spec.js
@@ -3,10 +3,26 @@
  *******************************************************************************/
 
 const config = JSON.parse(Cypress.env("TEST_CONFIG"));
-import { testInvalidApplicationInput } from "../../views/common";
+import {
+  testInvalidApplicationInput,
+  testGitApiInput
+} from "../../views/common";
 
-describe("Application UI: [P1][Sev1][app-lifecycle-ui] Application Creation Validate invalid input Test", () => {
+describe("Application UI: [P2][Sev2][app-lifecycle-ui] Application Creation Validate invalid input Test", () => {
   it(`Verify invalid input is rejected`, () => {
     testInvalidApplicationInput();
+  });
+});
+
+describe("Application UI: [P3][Sev3][app-lifecycle-ui] Application Creation Validate git api Test", () => {
+  it(`Verify git api can access git branches`, () => {
+    for (const type in config) {
+      const apps = config[type].data;
+      apps.forEach(data => {
+        if (data.enable && data.new && type === "git") {
+          testGitApiInput(data);
+        }
+      });
+    }
   });
 });

--- a/tests/cypress/views/application.js
+++ b/tests/cypress/views/application.js
@@ -91,26 +91,22 @@ export const gitTasks = (clusterName, value, gitCss, key = 0) => {
   }
   // type in branch and path
   cy.get(".bx—inline.loading", { timeout: 30 * 1000 }).should("not.exist");
-  if (url.indexOf("github.com") >= 0) {
-    cy.get(gitBranch, { timeout: 50 * 1000 }).click();
-    cy.contains(".tf--list-box__menu-item", new RegExp(`^${branch}$`)).click();
-  } else {
-    cy
-      .get(gitBranch, { timeout: 50 * 1000 })
-      .type(branch, { timeout: 50 * 1000 })
-      .blur();
-  }
+  //type in branch name here instead of trying to select one
+  // the git api is unreliable and we don't want to fail all git app tests
+  //if the branch doesn't show up
+  cy
+    .get(gitBranch, { timeout: 50 * 1000 })
+    .type(branch, { timeout: 50 * 1000 })
+    .blur();
+
   cy.wait(1000);
   cy.get(".bx—inline.loading", { timeout: 30 * 1000 }).should("not.exist");
-  if (url.indexOf("github.com") >= 0) {
-    cy.get(gitPath, { timeout: 20 * 1000 }).click();
-    cy.contains(".tf--list-box__menu-item", new RegExp(`^${path}$`)).click();
-  } else {
-    cy
-      .get(gitPath, { timeout: 20 * 1000 })
-      .type(path, { timeout: 30 * 1000 })
-      .blur();
-  }
+  //type in folder name here instead of trying to select one, same reason as above, for branch
+  cy
+    .get(gitPath, { timeout: 20 * 1000 })
+    .type(path, { timeout: 30 * 1000 })
+    .blur();
+
   if (gitReconcileOption) {
     cy
       .get(merge)
@@ -835,7 +831,11 @@ export const addNewSubscription = (
   submitSave(true);
 };
 
-export const verifyEditAfterDeleteSubscription = (name, data, namespace = "default") => {
+export const verifyEditAfterDeleteSubscription = (
+  name,
+  data,
+  namespace = "default"
+) => {
   namespace == "default" ? (namespace = `${name}-ns`) : namespace;
   if (data.config.length > 1) {
     edit(name, namespace);

--- a/tests/cypress/views/common.js
+++ b/tests/cypress/views/common.js
@@ -4,6 +4,7 @@
  ****************************************************************************** */
 
 /// <reference types="cypress" />
+import { checkExistingUrls } from "./resources.js";
 
 export const pageLoader = {
   shouldExist: () =>
@@ -791,6 +792,65 @@ export const testDefect7080 = () => {
 
   cy.log("Test defect 7080 - now go back to default option");
   cy.get("#local-cluster-checkbox").click({ force: true });
+};
+
+//verify that as we select the git api, we get the branch and path information
+export const testGitApiInput = data => {
+  const { config } = data;
+  const { url, branch, path, username, token } = config[0];
+  const gitCss = {
+    gitUrl: "#githubURL",
+    gitUser: "#githubUser",
+    gitKey: "#githubAccessId",
+    gitBranch: "#githubBranch",
+    gitPath: "#githubPath",
+    merge: "#gitReconcileOption",
+    insecureSkipVerify: "#gitInsecureSkipVerify"
+  };
+
+  const { gitUrl, gitUser, gitKey, gitBranch, gitPath } = gitCss;
+
+  cy.visit("/multicloud/applications");
+  // wait for create button to be enabled
+  cy.get("[data-test-create-application=true]", { timeout: 50 * 1000 }).click();
+  cy.get(".bx--detail-page-header-title-container").should("exist");
+
+  cy.log("Select git url");
+  cy
+    .get("#git", { timeout: 20 * 1000 })
+    .click({ force: true })
+    .trigger("mouseover");
+
+  cy
+    .get(gitUrl, { timeout: 20 * 1000 })
+    .type(url, { timeout: 50 * 1000 })
+    .blur();
+  checkExistingUrls(gitUser, username, gitKey, token, url);
+
+  // check branch and path info shows up
+  cy.get(".bx—inline.loading", { timeout: 30 * 1000 }).should("not.exist");
+  if (url.indexOf("github.com") >= 0) {
+    cy.get(gitBranch, { timeout: 50 * 1000 }).click();
+    cy.contains(".tf--list-box__menu-item", new RegExp(`^${branch}$`)).click();
+  } else {
+    cy.log("Nothing to test");
+    cy
+      .get(gitBranch, { timeout: 50 * 1000 })
+      .type(branch, { timeout: 50 * 1000 })
+      .blur();
+  }
+
+  cy.wait(1000);
+  cy.get(".bx—inline.loading", { timeout: 30 * 1000 }).should("not.exist");
+  if (url.indexOf("github.com") >= 0) {
+    cy.get(gitPath, { timeout: 20 * 1000 }).click();
+    cy.contains(".tf--list-box__menu-item", new RegExp(`^${path}$`)).click();
+  } else {
+    cy
+      .get(gitPath, { timeout: 20 * 1000 })
+      .type(path, { timeout: 30 * 1000 })
+      .blur();
+  }
 };
 
 export const testInvalidApplicationInput = () => {


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/9804

If the git api malfunctions and it can't select the branch , path, the git app is not created and an entire stack of tests are failing due to that
We should let the app creation pass even if the git api doesn't connect and return the branch/path info

I moved this into a separate test, marked as P3; we still validate branch / path selection but as a standalone test
