### PR TITLE
Fix apiVersion for Helm/Object resource nodes

### DIFF
--- a/src-web/components/Topology/viewer/defaults/details.js
+++ b/src-web/components/Topology/viewer/defaults/details.js
@@ -35,6 +35,7 @@ import msgs from '../../../../../nls/platform.properties'
 import { kubeNaming } from './titles'
 
 const resName = 'resource.name'
+const unknonwnApiVersion = 'unknown'
 
 export const getNodeDetails = (node, updatedNode, activeFilters) => {
   const details = []
@@ -162,7 +163,17 @@ function addK8Details(node, updatedNode, details, activeFilters) {
   const reconcileRateAnnotation =
     'apps.open-cluster-management.io/reconcile-rate'
 
-  const apiVersion = _.get(node, 'specs.raw.apiVersion', '')
+  const searchData = _.get(node, `specs.${type}Model`, {})
+  let apiVersion = _.get(node, 'specs.raw.apiVersion', '')
+  if (apiVersion === unknonwnApiVersion) {
+    if (Object.keys(searchData).length > 0) {
+      const firstSearchData = searchData[Object.keys(searchData)[0]][0]
+      apiVersion = firstSearchData.apigroup
+        ? `${firstSearchData.apigroup}/${firstSearchData.apiversion}`
+        : firstSearchData.apiversion
+    }
+  }
+
   // the main stuff
   const mainDetails = [
     {


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

https://github.com/open-cluster-management/backlog/issues/16644

- Look for the apiVersion from search results if set to unknown

<img width="1385" alt="image" src="https://user-images.githubusercontent.com/38960034/136463415-e91ab1e9-8cd5-429f-95b2-dd713554a747.png">
