### PR TITLE
Fix can't find .channel-labels-popover-content test failure

### DIFF
--- a/tests/cypress/views/common.js
+++ b/tests/cypress/views/common.js
@@ -134,7 +134,7 @@ export const resourceTable = {
         timeout: 30 * 10000
       })
       .type(name);
-    cy.wait(5000);
+    cy.wait(500);
   },
   openRowMenu: function(name, key) {
     cy


### PR DESCRIPTION
Related issue: https://github.com/open-cluster-management/backlog/issues/17253

- Add 5 seconds before trying to click on the channel popover label

From local e2e runs, it seemed that sometimes there might be a delay when the user enters the table search entry and when the table actually shows the search result rows. So I added 5 seconds to allow the table search enough time to display the results before trying to click on the channel popover.