### PR TITLE
Update ansible to stable channel

### DIFF
--- a/tests/cypress/templates/ansible_yaml/ansible-subscription.yaml
+++ b/tests/cypress/templates/ansible_yaml/ansible-subscription.yaml
@@ -1,12 +1,12 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: awx-resource-operator
+  name: ansible-automation-platform-operator
   namespace: app-ui-ansibleoperator
 spec:
-  channel: early-access-cluster-scoped
+  channel: stable-2.1-cluster-scoped
   installPlanApproval: Automatic
   name: ansible-automation-platform-operator
   source: redhat-operators  
   sourceNamespace: openshift-marketplace 
-  startingCSV: aap-operator.v2.0.1-0.1635283332
+  startingCSV: aap-operator.v2.1.0-0.1639592450

--- a/tests/start-cypress-tests.sh
+++ b/tests/start-cypress-tests.sh
@@ -65,7 +65,7 @@ if [[ "$CLEAN_UP" == "true" ]]; then
   oc delete namespace ui-helm-ns
   oc delete namespace ui-helm2-ns
   oc delete namespace ui-obj-ns
-  oc delete operator awx-resource-operator.app-ui-ansibleoperator
+  oc delete operator ansible-automation-platform-operator.app-ui-ansibleoperator
 
   echo "Clean up done. Exiting."
   exit 0


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

- Change name to Ansible automation platform as the resource operator is deprecated and removed
- Update ansible to stable channel
- Change ansible version