### PR TITLE
Remove Ansible version so it automatically installs the latest

### DIFF
--- a/tests/cypress/templates/ansible_yaml/ansible-subscription.yaml
+++ b/tests/cypress/templates/ansible_yaml/ansible-subscription.yaml
@@ -7,6 +7,5 @@ spec:
   channel: stable-2.1-cluster-scoped
   installPlanApproval: Automatic
   name: ansible-automation-platform-operator
-  source: redhat-operators  
-  sourceNamespace: openshift-marketplace 
-  startingCSV: aap-operator.v2.1.0-0.1639592450
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

Issues: 
- https://github.com/stolostron/backlog/issues/21700
- https://github.com/stolostron/backlog/issues/21762

- Remove the `startingCSV` version so the Ansbile operator will automatically install the latest version