### PR TITLE
Remove version to always install the latest Ansible operator for 2.4

### DIFF
--- a/tests/cypress/templates/ansible_yaml/ansible-subscription.yaml
+++ b/tests/cypress/templates/ansible_yaml/ansible-subscription.yaml
@@ -7,6 +7,5 @@ spec:
   channel: stable-2.1-cluster-scoped
   installPlanApproval: Automatic
   name: ansible-automation-platform-operator
-  source: redhat-operators  
-  sourceNamespace: openshift-marketplace 
-  startingCSV: aap-operator.v2.1.2-0.1649747734
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

Issues:
- https://github.com/stolostron/backlog/issues/21762
- https://github.com/stolostron/backlog/issues/21700

Changes:

- Remove ansible operator version to always install the latest operator that's available in the current OCP version