### PR TITLE
Switch Ansible operator to stable channel and remove startingCSV

### DIFF
--- a/tests/cypress/templates/ansible_yaml/ansible-subscription.yaml
+++ b/tests/cypress/templates/ansible_yaml/ansible-subscription.yaml
@@ -1,12 +1,11 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: awx-resource-operator
+  name: ansible-automation-platform-operator
   namespace: app-ui-ansibleoperator
 spec:
-  channel: early-access-cluster-scoped
+  channel: stable-2.1-cluster-scoped
   installPlanApproval: Automatic
   name: ansible-automation-platform-operator
-  source: redhat-operators  
-  sourceNamespace: openshift-marketplace 
-  startingCSV: aap-operator.v2.0.1-0.1635283332
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

Issues:

- https://github.com/stolostron/backlog/issues/21700
- https://github.com/stolostron/backlog/issues/21762

Change made:

- Switch Ansible operator to stable channel
- Remove startingCSV so we always install latest on current OCP version