### PR TITLE
Remove helm chart version to always install latest version for 2.4

### DIFF
--- a/tests/cypress/config/config.e2e.yaml
+++ b/tests/cypress/config/config.e2e.yaml
@@ -166,7 +166,6 @@ helm:
           password: ""
           chartName: redis
           packageAlias: redis
-          packageVersion: 12.2.4
           repositoryReconcileRate: medium
           deployment:
             local: false
@@ -177,7 +176,6 @@ helm:
           username: ""
           password: ""
           chartName: minio
-          packageVersion: 4.1.9
           timeWindow:
             setting: true
             type: blockinterval

--- a/tests/cypress/config/config.func.yaml
+++ b/tests/cypress/config/config.func.yaml
@@ -188,7 +188,6 @@ helm:
           password: ""
           chartName: redis
           packageAlias: redis
-          packageVersion: 12.2.4
           repositoryReconcileRate: medium
           deployment:
             local: false
@@ -199,7 +198,6 @@ helm:
           username: ""
           password: ""
           chartName: minio
-          packageVersion: 4.1.9
           timeWindow:
             setting: true
             type: blockinterval

--- a/tests/cypress/templates/argocd_yaml/argocd-operator.yaml
+++ b/tests/cypress/templates/argocd_yaml/argocd-operator.yaml
@@ -9,4 +9,3 @@ spec:
   name: openshift-gitops-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: openshift-gitops-operator.v1.4.5


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

Issue: https://github.com/stolostron/backlog/issues/23052

- Remove helm chart version to always install latest version
- Also removed Gitops operator version to always install the latest