### PR TITLE
Remove helm chart version to always install latest 2.2

### DIFF
--- a/tests/cypress/config/config.e2e.yaml
+++ b/tests/cypress/config/config.e2e.yaml
@@ -163,7 +163,6 @@ helm:
           username: ""
           password: ""
           chartName: redis
-          packageVersion: 12.2.4
           deployment:
             local: false
             online: false
@@ -173,7 +172,6 @@ helm:
           username: ""
           password: ""
           chartName: minio
-          packageVersion: 4.1.9
           timeWindow:
             setting: true
             type: blockinterval

--- a/tests/cypress/config/config.func.yaml
+++ b/tests/cypress/config/config.func.yaml
@@ -163,7 +163,6 @@ helm:
           username: ""
           password: ""
           chartName: redis
-          packageVersion: 12.2.4
           deployment:
             local: false
             online: false
@@ -173,7 +172,6 @@ helm:
           username: ""
           password: ""
           chartName: minio
-          packageVersion: 4.1.9
           timeWindow:
             setting: true
             type: blockinterval
@@ -195,7 +193,6 @@ helm:
           username: ""
           password: ""
           chartName: redis
-          packageVersion: 12.2.4
           deployment:
             local: false
             online: true


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

- Remove helm chart version to always install the latest